### PR TITLE
HIP: improve perf for quantized embedding forward kernel

### DIFF
--- a/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
+++ b/fbgemm_gpu/codegen/embedding_forward_quantized_split_template.cu
@@ -294,10 +294,10 @@ __global__ void {{ type_map[emb_weight_type].enum_name }}_split_embedding{{ "_no
     // equivalent to fence + wait.
     cp_async_wait<0>();
 #ifdef __HIP_PLATFORM_HCC__
-    // performance: replace global __syncthreads with per CU __threadfence_block
-    // __threadfence_block is perfectly fine replacement for __syncwarp, because
+    // Performance - replace a block level __syncthreads with per CU __threadfence_block
+    // __threadfence_block is fine replacement for __syncwarp on AMD GPUs, it is because
     // a. memory fencing: __threadfence_block ops. at CU level, same as __syncwarp at SM
-    // b. thread re-converge: __syncwarp at scope of warp; AMD wave executes in lockstep
+    // b. threads re-converge: wave executes in lockstep, no need __syncwarp re-converge
     __threadfence_block();
 #else
     __syncwarp();


### PR DESCRIPTION
On AMD Instinct MI250 system (optimization in progress), this increases performance by ~10% in case of fp32 weights, some lower for fp16 weights, for various types of output.

Relevant UTs passed:
===================
/workspace/FBGEMM/fbgemm_gpu# python test/split_table_batched_embeddings_test.py SplitTableBatchedEmbeddingsTest.test_nbit_forward_fused_pooled_emb_quant
/workspace/FBGEMM/fbgemm_gpu# python test/split_table_batched_embeddings_test.py SplitTableBatchedEmbeddingsTest.test_forward_fused_pooled_emb_quant

Performance result:
===================
Without this change
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=int8
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 569.37 GB/s, Time: 5702us, Memory Usage For Pruning: 0 GB
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=fp16
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 600.82 GB/s, Time: 5445us, Memory Usage For Pruning: 0 GB
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=fp32
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 610.87 GB/s, Time: 5438us, Memory Usage For Pruning: 0 GB

================
With this change
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=int8
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 621.27 GB/s, Time: 5225us, Memory Usage For Pruning: 0 GB
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=fp16
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 657.25 GB/s, Time: 4978us, Memory Usage For Pruning: 0 GB
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu#
$:/workspace/FBGEMM/fbgemm_gpu# python /workspace/FBGEMM/fbgemm_gpu/bench/split_table_batched_embeddings_benchmark.py nbit-device --num-tables=2 --embedding-dim=192 --num-embeddings=10000000 --batch-size=65536 --iters=100 --row-wise --alpha=1.0 --bag-size=32 --weights-precision=fp32 --output-dtype=fp32
INFO:root:fp32 Embedding tables: 20000000 rows, 3.84 GParam, 15.36 GB
INFO:root:Accessed weights per batch: 4194304 rows, 3.22 GB
... ...
INFO:root:Average of all iterations: fp32 Forward, B: 65536, E: 10000000, T: 2, D: 192, L: 32, W: False, BW: 665.69 GB/s, Time: 4990us, Memory Usage For Pruning: 0 GB
