### PR TITLE
adjust to adapt ROCm5.4

### DIFF
--- a/fbgemm_gpu/hip_kernel/split_tbe_fwd_hip.cpp
+++ b/fbgemm_gpu/hip_kernel/split_tbe_fwd_hip.cpp
@@ -60,7 +60,7 @@ __device__ half
 llvm_amdgcn_raw_buffer_load_fp16(int32x4_t srsrc,
                                  int32_t voffset,
                                  int32_t soffset,
-                                 int32_t glc_slc) __asm("llvm.amdgcn.raw.buffer.load.f16");
+                                 int32_t glc_slc) __asm("llvm.amdgcn.raw.buffer.load.i16");
 
 __device__ float
 llvm_amdgcn_raw_buffer_load_fp32(int32x4_t srsrc,
@@ -72,7 +72,7 @@ __device__ half2
 llvm_amdgcn_raw_buffer_load_fp16x2(int32x4_t srsrc,
                                    int32_t voffset,
                                    int32_t soffset,
-                                   int32_t glc_slc) __asm("llvm.amdgcn.raw.buffer.load.v2f16");
+                                   int32_t glc_slc) __asm("llvm.amdgcn.raw.buffer.load.i32");
 
 __device__ floatx2_t
 llvm_amdgcn_raw_buffer_load_fp32x2(int32x4_t srsrc,


### PR DESCRIPTION
Change the two intrinsic names to adapt ROCm5.4. Build and tests passed. 
[20221024_ROCm54_origin-performance_test_log.txt](https://github.com/ROCmSoftwarePlatform/FBGEMM/files/9871366/20221024_ROCm54_origin-performance_test_log.txt)
