### PR TITLE
Fix dense backward test

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -933,7 +933,6 @@ Tensor {{ embedding_cuda_op }}(
             if (static_cast<PoolingMode>(pooling_mode) == PoolingMode::MEAN) {
                 grad_output_mean = at::empty_like(grad_output_reshaped);
 
-                {%- if not dense or not vbe %}
                 FBGEMM_LAUNCH_KERNEL(
                     (grad_mean{{ vdesc }}_kernel<grad_t, index_t>),
                     div_round_up(total_B, kMaxThreads / kWarpSize),
@@ -953,7 +952,6 @@ Tensor {{ embedding_cuda_op }}(
                     FixedDivisor(total_B / T)
                     {%- endif %}
                 );
-                {%- endif %} // if not dense or not vbe
 
                 grad_output_accessor = MAKE_PTA_WITH_NAME("{{ embedding_cuda_op }}.2", grad_output_mean, grad_t, 2, 64);
             }

--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -36,12 +36,7 @@ from ..common import (
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import (
-        additional_decorators,
-        gradcheck,
-        optests,
-        use_cpu_strategy,
-    )
+    from test_utils import additional_decorators, gradcheck, optests, use_cpu_strategy
 else:
     from fbgemm_gpu.test.test_utils import (
         additional_decorators,
@@ -331,8 +326,10 @@ class BackwardDenseTest(unittest.TestCase):
         acc_B = 0
         for t in range(T_):
             B = Bs[t]
-            table_indice_weight_grad_mask = indice_weight_grad_mask[acc_B:acc_B + B * L]
-            table_indice_weight_grad_all = indice_weight_grad_all[acc_B:acc_B + B * L]
+            table_indice_weight_grad_mask = indice_weight_grad_mask[
+                acc_B : acc_B + B * L
+            ]
+            table_indice_weight_grad_all = indice_weight_grad_all[acc_B : acc_B + B * L]
             acc_B += B * L
             if feature_requires_grad[t]:
                 torch.testing.assert_close(

--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -9,7 +9,6 @@
 
 # pyre-ignore-all-errors[56]
 
-import os
 import unittest
 
 import hypothesis.strategies as st
@@ -41,7 +40,6 @@ if open_source:
         additional_decorators,
         gradcheck,
         optests,
-        skipIfRocm,
         use_cpu_strategy,
     )
 else:
@@ -49,7 +47,6 @@ else:
         additional_decorators,
         gradcheck,
         optests,
-        skipIfRocm,
         use_cpu_strategy,
     )
 
@@ -334,8 +331,8 @@ class BackwardDenseTest(unittest.TestCase):
         acc_B = 0
         for t in range(T_):
             B = Bs[t]
-            table_indice_weight_grad_mask = indice_weight_grad_mask[acc_B : acc_B + B * L]
-            table_indice_weight_grad_all = indice_weight_grad_all[acc_B : acc_B + B * L]
+            table_indice_weight_grad_mask = indice_weight_grad_mask[acc_B:acc_B + B * L]
+            table_indice_weight_grad_all = indice_weight_grad_all[acc_B:acc_B + B * L]
             acc_B += B * L
             if feature_requires_grad[t]:
                 torch.testing.assert_close(

--- a/fbgemm_gpu/test/tbe/training/backward_dense_test.py
+++ b/fbgemm_gpu/test/tbe/training/backward_dense_test.py
@@ -59,11 +59,6 @@ VERBOSITY: Verbosity = Verbosity.verbose
 
 @optests.generate_opcheck_tests(fast=True, additional_decorators=additional_decorators)
 class BackwardDenseTest(unittest.TestCase):
-    @unittest.skipIf(
-        os.getenv("GITHUB_ENV") is not None,
-        "This test is currently running into illegal memmory access issues in OSS, and is being investigated; please see https://github.com/pytorch/pytorch/issues/141904.",
-    )
-    @skipIfRocm("Currently runs into memory access issues")
     @given(
         T=st.integers(min_value=1, max_value=3),
         D=st.integers(min_value=2, max_value=128),
@@ -333,17 +328,24 @@ class BackwardDenseTest(unittest.TestCase):
         )
         y.sum().backward()
         indice_weight_grad_mask = per_sample_weights.grad.clone().cpu()
+        if not use_cpu:
+            torch.cuda.synchronize()
+
+        acc_B = 0
         for t in range(T_):
             B = Bs[t]
+            table_indice_weight_grad_mask = indice_weight_grad_mask[acc_B : acc_B + B * L]
+            table_indice_weight_grad_all = indice_weight_grad_all[acc_B : acc_B + B * L]
+            acc_B += B * L
             if feature_requires_grad[t]:
                 torch.testing.assert_close(
-                    indice_weight_grad_mask.view(T_, B, L)[t],
-                    indice_weight_grad_all.view(T_, B, L)[t],
+                    table_indice_weight_grad_mask,
+                    table_indice_weight_grad_all,
                 )
             else:
                 torch.testing.assert_close(
-                    indice_weight_grad_mask.view(T_, B, L)[t],
-                    torch.zeros_like(indice_weight_grad_mask.view(T_, B, L)[t]),
+                    table_indice_weight_grad_mask,
+                    torch.zeros_like(table_indice_weight_grad_mask),
                 )
 
         per_sample_weights = to_device(xw.contiguous().view(-1), use_cpu)


### PR DESCRIPTION
Attempt to fix dense unit test. There are currently 5 issues:

1. OOM (only on A100, hard to catch due to randomness of UTs)
2. Memory access error (both MI300X and A100, hard to catch)
3. Assertions failure in PoolingMode.MEAN test (both ROCm and Nvidia)
4. Assertions failure in PoolingMode.SUM test (both ROCm and Nvidia)
5. Wrong indexing in vbe test

Issues 1, 2, 5 are also observed in https://github.com/pytorch/FBGEMM/issues/3763

The initial intention of [aligned_grad_output_tensor_for_cuda_backwards()](https://github.com/pytorch/FBGEMM/compare/main...ROCm:FBGEMM:abokovoi/fix-dense-backward-test?expand=1#diff-ed28b3db0ed3eb525e480c13f149ae4894bb397f04eca8a6d6ffcd95b1caa890R297) function is unclear to me, so this fix particular might be "sub-optimal". Thus asking for some reviews