### PR TITLE
Optimizations for index_select_scalar_cumsum_kernel

### DIFF
--- a/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
@@ -83,7 +83,10 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
     if (is_last_thread) {
       scalar_t block_prev_local = 0;
       if (block_id != 0) {
-        volatile int* flags = block_flags;
+        // Spin wait for the previous block to write the sum value
+        while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
+          ;
+        
         // Get sum from the previous block
         *block_prev = block_prev_local = block_sums[block_id - 1];
       }

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
@@ -71,10 +71,11 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
     const int signal) {
 // ROCm path
 #ifdef USE_ROCM
+  // Perform scan within a block
   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
       .InclusiveSum(arr, arr);
 
-  // Perform stream scan across blocks
+  // Perform scan across blocks
   if (is_multi_block) {
     const bool is_last_thread =
         threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD;
@@ -106,10 +107,11 @@ __inline__ __device__ void inclusive_sum_scan_kernel(
   }
 #else
   // CUDA path
+  // Perform scan across blocks
   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
       .InclusiveSum(arr, arr);
 
-  // Perform stream scan across blocks
+  // Perform scan across blocks
   if (is_multi_block) {
     // The thread that holds the last entry in the block does synchronization
     if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
@@ -6,133 +6,132 @@
  * LICENSE file in the root directory of this source tree.
  */
 
- #pragma once
+#pragma once
 
- // clang-format off
- #ifdef USE_ROCM
- #define HIPCUB_ARCH 1
- #include <hipcub/backend/rocprim/block/block_scan.hpp>
- #else
- #include "fbgemm_gpu/utils/cub_namespace_prefix.cuh"
- #include <cub/block/block_scan.cuh>
- #include "fbgemm_gpu/utils/cub_namespace_postfix.cuh"
- #endif
- // clang-format on
- 
- namespace fbgemm_gpu {
- 
- #ifdef USE_ROCM
- namespace cub = hipcub;
- #endif
- 
- /**
-  * inclusive_sum_scan_kernel performs intra- and inter-thread block sum scan
-  * (i.e., prefix sum scan). We use cub::BlockScan to do inclusive sum within
-  * thread block and use a waterfall sync method to perform prefix sum across
-  * thread block.
-  *
-  * @param arr an array of input values. Its length must be fixed to
-  *            ITEMS_PER_THREAD
-  * @param temp_storage a shared memory struct for cub::BlockScan
-  * @param block_flags a global flag buffer for inter-block sync (must be
-  *                    initialized with zeros)
-  * @param block_sums a global sum buffer for inter-block sync
-  * @param block_prev a shared memory pointer for sharing sum from the previous
-  *                   block within a block
-  * @param num_entries_per_block a number of input entries for this block
-  * @param block_id a relative thread block ID (the first block that contains
-  *                 the first set of input entries has block_id = 0)
-  * @param is_multi_block a boolean to indicate if inter-block sum scan has to
-  *                       be performed
-  * @param signal If the value of block_flags of the previous block is equal to
-  *               signal, it means that the previous block has written its sum
-  *               to block_sums. We have thread blocks increment the value of
-  *               block_flags by one after they write their sums to block_sums.
-  *               We increment the flag instead of setting the flag to a single
-  *               value to support multiple sequential inclusive_sum_scan_kernel
-  *               calls (e.g., in the AUC kernel). signal is the order that
-  *               inclusive_sum_scan_kernel is called. Since we intialize
-  *               block_flags with zeros, the signal of the first call should be
-  *               one.
-  */
- template <typename scalar_t, int ITEMS_PER_THREAD, int NUM_THREADS_PER_BLOCK>
- __inline__ __device__ void inclusive_sum_scan_kernel(
-     scalar_t (&arr)[ITEMS_PER_THREAD],
-     typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
-         temp_storage,
-     int* block_flags,
-     // Declared as volatile to prevent the compiler from register-allocating
-     // the accesses to block_sums
-     volatile scalar_t* block_sums,
-     scalar_t* block_prev,
-     const int num_entries_per_block,
-     const int block_id,
-     const bool is_multi_block,
-     const int signal) {
- // ROCm path
- #ifdef USE_ROCM
-   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
-       .InclusiveSum(arr, arr);
- 
-   if (is_multi_block) {
-     const bool is_last_thread =
-         threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD;
- 
-     if (is_last_thread) {
-       scalar_t block_prev_local = 0;
-       if (block_id != 0) {
-         volatile int* flags = block_flags;
-         *block_prev = block_prev_local = block_sums[block_id - 1];
-       }
- 
-       // Write sum to global memory for the next block to consume
-       const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
-       block_sums[block_id] = block_prev_local + arr[scope];
-       __threadfence();
-       // Set a flag to notify the next block
-       atomicExch(&block_flags[block_id], signal);
-     }
- 
-     __syncthreads();
- 
-     if (block_id != 0) {
-       scalar_t block_prev_local = *block_prev;
-       for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-         arr[i] += block_prev_local;
-       }
-     }
-   }
- #else
-   // CUDA path
-   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
-       .InclusiveSum(arr, arr);
- 
-   if (is_multi_block) {
-     if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {
-       scalar_t block_prev_local = 0;
-       if (block_id != 0) {
-         while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
-           ;
- 
-         *block_prev = block_prev_local = block_sums[block_id - 1];
-       }
- 
-       const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
-       block_sums[block_id] = block_prev_local + arr[scope];
-       __threadfence();
-       atomicAdd(&block_flags[block_id], 1);
-     }
- 
-     __syncthreads();
- 
-     if (block_id != 0) {
-       scalar_t block_prev_local = *block_prev;
-       for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-         arr[i] += block_prev_local;
-       }
-     }
-   }
- #endif
- }
- } // namespace fbgemm_gpu
- 
+// clang-format off
+#ifdef USE_ROCM
+#define HIPCUB_ARCH 1
+#include <hipcub/backend/rocprim/block/block_scan.hpp>
+#else
+#include "fbgemm_gpu/utils/cub_namespace_prefix.cuh"
+#include <cub/block/block_scan.cuh>
+#include "fbgemm_gpu/utils/cub_namespace_postfix.cuh"
+#endif
+// clang-format on
+
+namespace fbgemm_gpu {
+
+#ifdef USE_ROCM
+namespace cub = hipcub;
+#endif
+
+/**
+ * inclusive_sum_scan_kernel performs intra- and inter-thread block sum scan
+ * (i.e., prefix sum scan). We use cub::BlockScan to do inclusive sum within
+ * thread block and use a waterfall sync method to perform prefix sum across
+ * thread block.
+ *
+ * @param arr an array of input values. Its length must be fixed to
+ *            ITEMS_PER_THREAD
+ * @param temp_storage a shared memory struct for cub::BlockScan
+ * @param block_flags a global flag buffer for inter-block sync (must be
+ *                    initialized with zeros)
+ * @param block_sums a global sum buffer for inter-block sync
+ * @param block_prev a shared memory pointer for sharing sum from the previous
+ *                   block within a block
+ * @param num_entries_per_block a number of input entries for this block
+ * @param block_id a relative thread block ID (the first block that contains
+ *                 the first set of input entries has block_id = 0)
+ * @param is_multi_block a boolean to indicate if inter-block sum scan has to
+ *                       be performed
+ * @param signal If the value of block_flags of the previous block is equal to
+ *               signal, it means that the previous block has written its sum
+ *               to block_sums. We have thread blocks increment the value of
+ *               block_flags by one after they write their sums to block_sums.
+ *               We increment the flag instead of setting the flag to a single
+ *               value to support multiple sequential inclusive_sum_scan_kernel
+ *               calls (e.g., in the AUC kernel). signal is the order that
+ *               inclusive_sum_scan_kernel is called. Since we intialize
+ *               block_flags with zeros, the signal of the first call should be
+ *               one.
+ */
+template <typename scalar_t, int ITEMS_PER_THREAD, int NUM_THREADS_PER_BLOCK>
+__inline__ __device__ void inclusive_sum_scan_kernel(
+    scalar_t (&arr)[ITEMS_PER_THREAD],
+    typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
+        temp_storage,
+    int* block_flags,
+    // Declared as volatile to prevent the compiler from register-allocating
+    // the accesses to block_sums
+    volatile scalar_t* block_sums,
+    scalar_t* block_prev,
+    const int num_entries_per_block,
+    const int block_id,
+    const bool is_multi_block,
+    const int signal) {
+// ROCm path
+#ifdef USE_ROCM
+  cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
+      .InclusiveSum(arr, arr);
+
+  if (is_multi_block) {
+    const bool is_last_thread =
+        threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD;
+
+    if (is_last_thread) {
+      scalar_t block_prev_local = 0;
+      if (block_id != 0) {
+        volatile int* flags = block_flags;
+        *block_prev = block_prev_local = block_sums[block_id - 1];
+      }
+
+      // Write sum to global memory for the next block to consume
+      const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
+      block_sums[block_id] = block_prev_local + arr[scope];
+      __threadfence();
+      // Set a flag to notify the next block
+      atomicExch(&block_flags[block_id], signal);
+    }
+
+    __syncthreads();
+
+    if (block_id != 0) {
+      scalar_t block_prev_local = *block_prev;
+      for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        arr[i] += block_prev_local;
+      }
+    }
+  }
+#else
+  // CUDA path
+  cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
+      .InclusiveSum(arr, arr);
+
+  if (is_multi_block) {
+    if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {
+      scalar_t block_prev_local = 0;
+      if (block_id != 0) {
+        while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
+          ;
+
+        *block_prev = block_prev_local = block_sums[block_id - 1];
+      }
+
+      const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
+      block_sums[block_id] = block_prev_local + arr[scope];
+      __threadfence();
+      atomicAdd(&block_flags[block_id], 1);
+    }
+
+    __syncthreads();
+
+    if (block_id != 0) {
+      scalar_t block_prev_local = *block_prev;
+      for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+        arr[i] += block_prev_local;
+      }
+    }
+  }
+#endif
+}
+} // namespace fbgemm_gpu

--- a/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
+++ b/fbgemm_gpu/include/fbgemm_gpu/utils/inclusive_sum_scan.cuh
@@ -6,104 +6,133 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#pragma once
+ #pragma once
 
-// clang-format off
-#ifdef USE_ROCM
-#define HIPCUB_ARCH 1
-#include <hipcub/backend/rocprim/block/block_scan.hpp>
-#else
-#include "fbgemm_gpu/utils/cub_namespace_prefix.cuh"
-#include <cub/block/block_scan.cuh>
-#include "fbgemm_gpu/utils/cub_namespace_postfix.cuh"
-#endif
-// clang-format on
-
-namespace fbgemm_gpu {
-
-#ifdef USE_ROCM
-namespace cub = hipcub;
-#endif
-
-/**
- * inclusive_sum_scan_kernel performs intra- and inter-thread block sum scan
- * (i.e., prefix sum scan). We use cub::BlockScan to do inclusive sum within
- * thread block and use a waterfall sync method to perform prefix sum across
- * thread block.
- *
- * @param arr an array of input values. Its length must be fixed to
- *            ITEMS_PER_THREAD
- * @param temp_storage a shared memory struct for cub::BlockScan
- * @param block_flags a global flag buffer for inter-block sync (must be
- *                    initialized with zeros)
- * @param block_sums a global sum buffer for inter-block sync
- * @param block_prev a shared memory pointer for sharing sum from the previous
- *                   block within a block
- * @param num_entries_per_block a number of input entries for this block
- * @param block_id a relative thread block ID (the first block that contains
- *                 the first set of input entries has block_id = 0)
- * @param is_multi_block a boolean to indicate if inter-block sum scan has to
- *                       be performed
- * @param signal If the value of block_flags of the previous block is equal to
- *               signal, it means that the previous block has written its sum
- *               to block_sums. We have thread blocks increment the value of
- *               block_flags by one after they write their sums to block_sums.
- *               We increment the flag instead of setting the flag to a single
- *               value to support multiple sequential inclusive_sum_scan_kernel
- *               calls (e.g., in the AUC kernel). signal is the order that
- *               inclusive_sum_scan_kernel is called. Since we intialize
- *               block_flags with zeros, the signal of the first call should be
- *               one.
- */
-template <typename scalar_t, int ITEMS_PER_THREAD, int NUM_THREADS_PER_BLOCK>
-__inline__ __device__ void inclusive_sum_scan_kernel(
-    scalar_t (&arr)[ITEMS_PER_THREAD],
-    typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
-        temp_storage,
-    int* block_flags,
-    // Declared as volatile to prevent the compiler from register-allocating
-    // the accesses to block_sums
-    volatile scalar_t* block_sums,
-    scalar_t* block_prev,
-    const int num_entries_per_block,
-    const int block_id,
-    const bool is_multi_block,
-    const int signal) {
-  // Perform scan within a block
-  cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
-      .InclusiveSum(arr, arr);
-
-  // Perform stream scan across blocks
-  if (is_multi_block) {
-    // The thread that holds the last entry in the block does synchronization
-    if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {
-      scalar_t block_prev_local = 0;
-      if (block_id != 0) {
-        // Spin wait for the previous block to write the sum value
-        while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
-          ;
-
-        // Get sum from the previous block
-        *block_prev = block_prev_local = block_sums[block_id - 1];
-      }
-
-      // Write sum to global memory for the next block to consume
-      const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
-      block_sums[block_id] = block_prev_local + arr[scope];
-      __threadfence();
-      // Set a flag to notify the next block
-      atomicAdd(&block_flags[block_id], 1);
-    }
-
-    __syncthreads();
-
-    if (block_id != 0) {
-      scalar_t block_prev_local = *block_prev;
-      for (int i = 0; i < ITEMS_PER_THREAD; i++) {
-        arr[i] += block_prev_local;
-      }
-    }
-  }
-}
-
-} // namespace fbgemm_gpu
+ // clang-format off
+ #ifdef USE_ROCM
+ #define HIPCUB_ARCH 1
+ #include <hipcub/backend/rocprim/block/block_scan.hpp>
+ #else
+ #include "fbgemm_gpu/utils/cub_namespace_prefix.cuh"
+ #include <cub/block/block_scan.cuh>
+ #include "fbgemm_gpu/utils/cub_namespace_postfix.cuh"
+ #endif
+ // clang-format on
+ 
+ namespace fbgemm_gpu {
+ 
+ #ifdef USE_ROCM
+ namespace cub = hipcub;
+ #endif
+ 
+ /**
+  * inclusive_sum_scan_kernel performs intra- and inter-thread block sum scan
+  * (i.e., prefix sum scan). We use cub::BlockScan to do inclusive sum within
+  * thread block and use a waterfall sync method to perform prefix sum across
+  * thread block.
+  *
+  * @param arr an array of input values. Its length must be fixed to
+  *            ITEMS_PER_THREAD
+  * @param temp_storage a shared memory struct for cub::BlockScan
+  * @param block_flags a global flag buffer for inter-block sync (must be
+  *                    initialized with zeros)
+  * @param block_sums a global sum buffer for inter-block sync
+  * @param block_prev a shared memory pointer for sharing sum from the previous
+  *                   block within a block
+  * @param num_entries_per_block a number of input entries for this block
+  * @param block_id a relative thread block ID (the first block that contains
+  *                 the first set of input entries has block_id = 0)
+  * @param is_multi_block a boolean to indicate if inter-block sum scan has to
+  *                       be performed
+  * @param signal If the value of block_flags of the previous block is equal to
+  *               signal, it means that the previous block has written its sum
+  *               to block_sums. We have thread blocks increment the value of
+  *               block_flags by one after they write their sums to block_sums.
+  *               We increment the flag instead of setting the flag to a single
+  *               value to support multiple sequential inclusive_sum_scan_kernel
+  *               calls (e.g., in the AUC kernel). signal is the order that
+  *               inclusive_sum_scan_kernel is called. Since we intialize
+  *               block_flags with zeros, the signal of the first call should be
+  *               one.
+  */
+ template <typename scalar_t, int ITEMS_PER_THREAD, int NUM_THREADS_PER_BLOCK>
+ __inline__ __device__ void inclusive_sum_scan_kernel(
+     scalar_t (&arr)[ITEMS_PER_THREAD],
+     typename cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>::TempStorage&
+         temp_storage,
+     int* block_flags,
+     // Declared as volatile to prevent the compiler from register-allocating
+     // the accesses to block_sums
+     volatile scalar_t* block_sums,
+     scalar_t* block_prev,
+     const int num_entries_per_block,
+     const int block_id,
+     const bool is_multi_block,
+     const int signal) {
+ // ROCm path
+ #ifdef USE_ROCM
+   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
+       .InclusiveSum(arr, arr);
+ 
+   if (is_multi_block) {
+     const bool is_last_thread =
+         threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD;
+ 
+     if (is_last_thread) {
+       scalar_t block_prev_local = 0;
+       if (block_id != 0) {
+         volatile int* flags = block_flags;
+         *block_prev = block_prev_local = block_sums[block_id - 1];
+       }
+ 
+       // Write sum to global memory for the next block to consume
+       const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
+       block_sums[block_id] = block_prev_local + arr[scope];
+       __threadfence();
+       // Set a flag to notify the next block
+       atomicExch(&block_flags[block_id], signal);
+     }
+ 
+     __syncthreads();
+ 
+     if (block_id != 0) {
+       scalar_t block_prev_local = *block_prev;
+       for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+         arr[i] += block_prev_local;
+       }
+     }
+   }
+ #else
+   // CUDA path
+   cub::BlockScan<scalar_t, NUM_THREADS_PER_BLOCK>(temp_storage)
+       .InclusiveSum(arr, arr);
+ 
+   if (is_multi_block) {
+     if (threadIdx.x == (num_entries_per_block - 1) / ITEMS_PER_THREAD) {
+       scalar_t block_prev_local = 0;
+       if (block_id != 0) {
+         while (atomicAdd(&block_flags[block_id - 1], 0) < signal)
+           ;
+ 
+         *block_prev = block_prev_local = block_sums[block_id - 1];
+       }
+ 
+       const int scope = (num_entries_per_block - 1) % ITEMS_PER_THREAD;
+       block_sums[block_id] = block_prev_local + arr[scope];
+       __threadfence();
+       atomicAdd(&block_flags[block_id], 1);
+     }
+ 
+     __syncthreads();
+ 
+     if (block_id != 0) {
+       scalar_t block_prev_local = *block_prev;
+       for (int i = 0; i < ITEMS_PER_THREAD; i++) {
+         arr[i] += block_prev_local;
+       }
+     }
+   }
+ #endif
+ }
+ } // namespace fbgemm_gpu
+ 

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -284,13 +284,13 @@ class KeyedJaggedIndexSelectDim1GPUOp
     Tensor output_lengths =
         at::empty({num_batches * indices.numel()}, lengths.options());
 
-    // Do index select and cumsum
     Tensor block_flags, block_sums;
     if (grid_size > 1) {
       block_flags = at::zeros({grid_size}, lengths.options().dtype(at::kInt));
       block_sums = at::empty({grid_size}, output_offsets.options());
     }
 
+    // Do index select and cumsum
     AT_DISPATCH_INDEX_TYPES(
         lengths.scalar_type(), "index_select_scalar_cumsum_wrapper_1", [&] {
           using length_t = index_t;

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -289,6 +289,9 @@ class KeyedJaggedIndexSelectDim1GPUOp
           MAX_CUMSUM_ENTRIES_PER_BLOCK * ENTRIES_PER_THREAD;
       const auto grid_size = grid_calc(ENTRIES_PER_BLOCK);
 
+      if (grid_size == 0)
+        return;
+
       Tensor block_flags, block_sums;
       if (grid_size > 1) {
         block_flags =
@@ -326,10 +329,8 @@ class KeyedJaggedIndexSelectDim1GPUOp
                             PTA_B(indices, index_t, 1, 32),
                             num_batches,
                             batch_size,
-                            grid_size == 0
-                                ? 0
-                                : num_output_lengths -
-                                    ENTRIES_PER_BLOCK * (grid_size - 1),
+                            num_output_lengths -
+                                ENTRIES_PER_BLOCK * (grid_size - 1),
                             grid_size > 1
                                 ? block_flags.data_ptr<int>()
                                 : nullptr,

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -150,7 +150,7 @@ __global__ void index_select_scalar_cumsum_kernel(
   }
 #endif
 }
- 
+
 template <
     typename scalar_t,
     typename index_t,
@@ -284,7 +284,6 @@ class KeyedJaggedIndexSelectDim1GPUOp
     Tensor output_lengths =
         at::empty({num_batches * indices.numel()}, lengths.options());
 
-    // Do index select and cumsum
     // Do index select and cumsum
     Tensor block_flags, block_sums;
     if (grid_size > 1) {

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -144,7 +144,7 @@ __global__ void index_select_scalar_cumsum_kernel(
   }
 #endif
 }
- 
+
 template <
     typename scalar_t,
     typename index_t,

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -157,14 +157,6 @@ template <
     typename offset_t,
     typename weight_t,
     bool has_weights>
-
-// Total amount of user embeddings may not fit into GPU memory.
-// This kernel gathers a subset of users from a total amount of users.
-// Gathers raw user's embeddings from scattered memory locations and
-// writes them into contiguous memory locations.
-// The kernel takes one big jagged tensor containing all keys stacked 
-// together, and selects the same indices across all keys in a single operation.
-
 __global__ void keyed_jagged_index_select_dim1_kernel(
     pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,
     pta::PackedTensorAccessor64<weight_t, 1, at::RestrictPtrTraits>
@@ -213,7 +205,6 @@ __global__ void keyed_jagged_index_select_dim1_kernel(
   }
 }
 
-// Computes gradients for backpropagation during training.
 template <typename scalar_t, typename index_t, typename offset_t>
 __global__ void keyed_jagged_index_add_dim1_kernel(
     pta::PackedTensorAccessor64<scalar_t, 1, at::RestrictPtrTraits> output,

--- a/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
+++ b/fbgemm_gpu/src/jagged_tensor_ops/keyed_jagged_index_select_dim1.cu
@@ -7,7 +7,6 @@
  */
 
 #include <type_traits>
-
 #include "common.cuh"
 
 using Tensor = at::Tensor;
@@ -20,7 +19,6 @@ template <
     typename acc_t,
     int NUM_THREADS_PER_BLOCK,
     int MAX_ENTRIES_PER_BLOCK>
- 
 __global__ void index_select_scalar_cumsum_kernel(
     pta::PackedTensorAccessor32<scalar_t, 1, at::RestrictPtrTraits> output,
     pta::PackedTensorAccessor32<acc_t, 1, at::RestrictPtrTraits> output_cumsum,


### PR DESCRIPTION
## Optimization Changes
- Vectorized gather/store on ROCm: process 4/2/1 indices per thread, improving memory coalescing and bandwidth
- Fast path for single-block workloads, which uses a simple block scan and early return
- Multi-block cumsum uses a shared block prefix, reducing global synchronization overhead
- Auto-tuned vector width and block entry count at launch time to match indices length
- Guarded new ROCm changes using `#ifdef USE_ROCM`

## Test Result

Reduced the duration of index_select_scalar_cumsum_kernel by 1.11 us, yielding a 1.3x speedup.

## Test Plan
Unit test passed

<img width="783" height="214" alt="image" src="https://github.com/user-attachments/assets/297ea2be-3170-4e4e-bcb0-41e5ef1ddab3" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
