### PR TITLE
Implement asynchronous LDS loads for MI350

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -195,11 +195,6 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           row_valid_v[inner_i] = final_valid;
         }
 #if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800) || (defined(USE_ROCM) && defined(__gfx950__))
-        // Async-LDS path: cp_async_zfill_cg fires asynchronously on
-        // Ampere+ (cp.async) and MI350 (global_load_lds), so the fused
-        // per-iteration load+store is correct here. The weighted
-        // indice_weights write runs as a separate sweep to keep the row
-        // loads tight.
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
           uint32_t i = outer_i + inner_i;
@@ -231,14 +226,8 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
         }
         {% endif %}
 #else
-        // Synchronous fallback (e.g. MI300/gfx942): cp_async_zfill_cg's
-        // #else body is a per-lane predicated load+store. Fusing it per
-        // iteration kills load pipelining (each store depends on its
-        // load, so the compiler emits N waitcnts instead of one) and
-        // adds wave divergence on mixed-validity warps. Restore the
-        // original unfused load followed by masked store so the
-        // compiler can issue all kRowUnroll global loads back-to-back
-        // behind a single waitcnt.
+        // Maintain pipelining of load and store operations when async shared memory/lds
+        // loads are not available.
         uint4 row_data_v[kRowUnroll];
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {

--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_kernel_template.cu
@@ -194,6 +194,12 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           }
           row_valid_v[inner_i] = final_valid;
         }
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800) || (defined(USE_ROCM) && defined(__gfx950__))
+        // Async-LDS path: cp_async_zfill_cg fires asynchronously on
+        // Ampere+ (cp.async) and MI350 (global_load_lds), so the fused
+        // per-iteration load+store is correct here. The weighted
+        // indice_weights write runs as a separate sweep to keep the row
+        // loads tight.
         #pragma unroll
         for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
           uint32_t i = outer_i + inner_i;
@@ -224,6 +230,42 @@ __global__ void {{ emb_weight_type.enum_name }}_split_embedding{{ "_nobag" if no
           }
         }
         {% endif %}
+#else
+        // Synchronous fallback (e.g. MI300/gfx942): cp_async_zfill_cg's
+        // #else body is a per-lane predicated load+store. Fusing it per
+        // iteration kills load pipelining (each store depends on its
+        // load, so the compiler emits N waitcnts instead of one) and
+        // adds wave divergence on mixed-validity warps. Restore the
+        // original unfused load followed by masked store so the
+        // compiler can issue all kRowUnroll global loads back-to-back
+        // behind a single waitcnt.
+        uint4 row_data_v[kRowUnroll];
+        #pragma unroll
+        for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
+          row_data_v[inner_i] = row_v[inner_i][row_load_idx];
+        }
+        uint4 zeros = {0, 0, 0, 0};
+        #pragma unroll
+        for (uint32_t inner_i = 0; inner_i < kRowUnroll; inner_i++) {
+          uint32_t i = outer_i + inner_i;
+          bool final_valid = row_valid_v[inner_i];
+          uint4 data = final_valid ? row_data_v[inner_i] : zeros;
+          if constexpr (PackedMode) {
+            // Store row data with uint4_loads_per_row offset
+            buffers[warp_idx][i][input_row_idx][row_load_idx + uint4_loads_per_row * packed_bag_load_idx] = data;
+          } else {
+            buffers[warp_idx][i][input_row_idx][row_load_idx] = data;
+          }
+          {% if weighted %}
+          if (row_load_idx == 0)  {
+            // Use only one thread to load the index weight to prevent a race
+            // condition when writing to the shared memory
+            buffers_indice_weights[warp_idx][i][input_row_idx][packed_bag_load_idx] =
+              final_valid ? indice_weights[indices_starts[i] + L_start + input_row_idx] : 0.0;
+          }
+          {% endif %}
+        }
+#endif
       }
       {%- endif %}
 


### PR DESCRIPTION
This PR implements direct HBM->LDS stores in tbe inference kernel. There are 2 major changes:

1. Rows data isn't loaded in-place, instead we store pointers to global memory and store the actual data w.r.t. the predicate into LDS. In case predicate is false, we pre-allocate small chunk of static device memory of 16B once, fill it with zeros, and fallback to this chunk
2. HBM->LDS 16B loads are implemented for ROCm >= 7.0 and MI350. We can expand the support range to MI30* through 4B loads, however it doesn't bring any performance benefits because we'll have to introduce an overhead of addresses transposition and 4x more load operations. You can find out the reference implementation here: https://github.com/pytorch/FBGEMM/commit/fe525574deeb550ab50660fef5a8fbdbedbfc718. 

Due to pre-7.2 ROCm features, we are forced to used assembly inline to get 16B loads to work, so manual synchronization was added. In case of ROCm >= 7.2, we use proper intrinsics to handle memory synchronization. 

This change brings ~10% performance boost on average for weighted and unweighted cases. We may try to push it further by doing async loads for indices weights.

cc: @amirakb89 you might be interested