### PR TITLE
Enable block_bucketize* tests on ROCm

### DIFF
--- a/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_2d_weights_test.py
@@ -19,11 +19,10 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, skipIfRocm
+    from test_utils import gpu_available
 else:
-    from fbgemm_gpu.test.test_utils import gpu_available, skipIfRocm
+    from fbgemm_gpu.test.test_utils import gpu_available
 
-ROCM_FAILURE_MESSAGE = "Test is causing HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION"
 
 
 class BlockBucketize2DWeightsTest(unittest.TestCase):
@@ -50,7 +49,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                     self.assertAlmostEqual(left, right)
         return
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -170,7 +168,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                 # but we can verify that all dimensions are preserved
                 self.assertEqual(new_weights_gpu.shape[1], weights_dim)
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -326,7 +323,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                         pos_1d_gpu, pos_2d_gpu, lengths_1d_gpu
                     )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -474,7 +470,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                 indices_seq_gpu.cpu(), indices_pooled_gpu.cpu(), lengths_seq_gpu.cpu()
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -586,7 +581,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                     indices_out, indices_out_gpu.cpu(), lengths_out
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -692,7 +686,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                     indices_out, indices_out_gpu.cpu(), lengths_out
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -794,7 +787,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                     indices_out, indices_out_gpu.cpu(), lengths_out
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),
@@ -904,7 +896,6 @@ class BlockBucketize2DWeightsTest(unittest.TestCase):
                     indices_out, indices_out_gpu.cpu(), lengths_out
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),

--- a/fbgemm_gpu/test/sparse/block_bucketize_test.py
+++ b/fbgemm_gpu/test/sparse/block_bucketize_test.py
@@ -21,11 +21,10 @@ from .common import extend_test_class, open_source
 
 if open_source:
     # pyre-ignore[21]
-    from test_utils import gpu_available, skipIfRocm
+    from test_utils import gpu_available
 else:
-    from fbgemm_gpu.test.test_utils import gpu_available, skipIfRocm
+    from fbgemm_gpu.test.test_utils import gpu_available
 
-ROCM_FAILURE_MESSAGE = "Test is causing HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION"
 
 
 def unbucketize_indices_value(
@@ -74,7 +73,6 @@ class BlockBucketizeTest(unittest.TestCase):
                     self.assertAlmostEqual(left, right)
         return
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -273,7 +271,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 torch.testing.assert_close(new_indices_gpu.cpu(), new_indices_ref)
                 torch.testing.assert_close(new_indices_gpu.cpu(), new_indices_cpu)
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -470,7 +467,6 @@ class BlockBucketizeTest(unittest.TestCase):
             msg=f"{new_indices.cpu()=} != {new_indices_ref=}",
         )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -606,7 +602,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 msg=f"{unbucketize_permute=}",
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -730,7 +725,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 msg=f"{unbucketize_permute=}",
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -842,7 +836,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 msg=f"{unbucketize_permute=}",
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         long_indices=st.booleans(),
         use_cpu=st.booleans() if gpu_available else st.just(True),
@@ -953,7 +946,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 msg=f"{unbucketize_permute=}",
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         has_weight=st.booleans(),
@@ -1121,7 +1113,6 @@ class BlockBucketizeTest(unittest.TestCase):
                         new_pos_ref, new_pos_gpu.cpu(), new_lengths_ref
                     )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
     )
@@ -1201,7 +1192,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 bucket_mapping,
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
     )
@@ -1385,7 +1375,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 atol=0,
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         my_size=st.integers(min_value=1, max_value=16),
@@ -1410,7 +1399,6 @@ class BlockBucketizeTest(unittest.TestCase):
             lengths, indices, block_sizes, my_size, index_type
         )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         num_sequences=st.integers(min_value=1, max_value=16),
@@ -1433,7 +1421,6 @@ class BlockBucketizeTest(unittest.TestCase):
             lengths, indices, block_sizes, my_size, index_type
         )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         my_size=st.integers(min_value=33, max_value=64),
@@ -1458,7 +1445,6 @@ class BlockBucketizeTest(unittest.TestCase):
             lengths, indices, block_sizes, my_size, index_type
         )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         my_size=st.integers(min_value=1, max_value=32),
@@ -1480,7 +1466,6 @@ class BlockBucketizeTest(unittest.TestCase):
             lengths, indices, block_sizes, my_size, index_type
         )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @unittest.skipIf(not gpu_available, "No GPU available")
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
@@ -1590,7 +1575,6 @@ class BlockBucketizeTest(unittest.TestCase):
                 f"my_size={my_size}, lengths={lengths}",
             )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         has_weight=st.booleans(),
@@ -1683,7 +1667,6 @@ class BlockBucketizeTest(unittest.TestCase):
                     new_indices_ref, new_indices_gpu.cpu(), new_lengths_ref
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         has_weight=st.booleans(),
@@ -1851,7 +1834,6 @@ class BlockBucketizeTest(unittest.TestCase):
                         is_int=False,
                     )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @unittest.skipIf(not gpu_available, "Skip is GPU is not available.")
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
@@ -1961,7 +1943,6 @@ class BlockBucketizeTest(unittest.TestCase):
                     new_pos_cpu, new_pos_gpu.cpu(), new_lengths_cpu
                 )
 
-    @skipIfRocm(ROCM_FAILURE_MESSAGE)
     @given(
         index_type=st.sampled_from([torch.int, torch.long]),
         bucketize_pos=st.booleans(),


### PR DESCRIPTION
`block_bucketize_2d_weights_test.py` and `block_bucketize_test.py` were disabled for ROCm due to "Test is causing HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION" reason. It's not reproducible locally anymore, so the tests are enabled to close the function gap with CUDA