### PR TITLE
Get actual free GPU memory in test_cache_int32_overflow

### DIFF
--- a/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
+++ b/fbgemm_gpu/test/tbe/cache/cache_overflow_test.py
@@ -39,8 +39,8 @@ class CacheOverflowTest(unittest.TestCase):
         cache_sets = 10**6
 
         current_device = torch.device(torch.cuda.current_device())
-        total_memory = torch.cuda.get_device_properties(current_device).total_memory
-        free_memory = total_memory - torch.cuda.memory_reserved(current_device)
+        free_memory, _ = torch.cuda.mem_get_info(current_device)
+        free_memory = int(free_memory * 0.8)
 
         # Weight and cache precisions are fixed to FP16
         element_size = 2


### PR DESCRIPTION
Address the following CI failure in `test_cache_int32_overflow` test:
```bash
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 122.07 GiB. GPU 0 has a total capacity of 255.98 GiB of which 50.64 GiB is free. Of the allocated memory 123.74 GiB is allocated by PyTorch, and 8.94 MiB is reserved by PyTorch but unallocated. If reserved but unallocated memory is large try setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to avoid fragmentation.  See documentation for Memory Management  (https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf)
```

https://github.com/pytorch/FBGEMM/actions/runs/24098433830/job/70328795853