### PR TITLE
[ROCm] cap num_packed_bags by warp lane capacity in nbit inference

### DIFF
--- a/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
+++ b/fbgemm_gpu/codegen/inference/embedding_forward_quantized_split_nbit_host_template.cu
@@ -245,6 +245,13 @@ Tensor int_nbit_split_embedding{{ "_nobag" if nobag else "" }}_codegen_forward_{
         constexpr int32_t NumUint4LoadsPerRow = MaxNum128BRows * 128 / sizeof(uint4); \
         /* Number of bags that might be fitted to shared memory. */                   \
         num_packed_bags = NumUint4LoadsPerRow > num_uint4_loads_per_row && !std::is_same_v<output_t, uint8_t> && sparse_type != SparseType::FP32 ? NumUint4LoadsPerRow / num_uint4_loads_per_row : 1; \
+        /* Cap by what the accumulate/store stage can address: it maps */ \
+        /* packed_bag_*_idx = threadIdx.x / uints_per_row, so we need */ \
+        /* num_packed_bags * uints_per_row <= kWarpSize. Without this cap, */ \
+        /* on warpSize=32 (RDNA) the trailing bags are never written. */ \
+        const int32_t uints_per_row_host = 4 /* uints per uint4 */ * num_uint4_loads_per_row; \
+        const int32_t max_bags_by_warp = uints_per_row_host > 0 ? kWarpSizeHost() / uints_per_row_host : 1; \
+        num_packed_bags = std::min(num_packed_bags, std::max(1, max_bags_by_warp)); \
       } \
       {%- endif %}
       if (num_packed_bags > 1) {              \


### PR DESCRIPTION
## Fix for numerical error in tbe with packed_bag mode on Cards with wave_size=32.
The packed-bags kernel maps `packed_bag_*_idx = threadIdx.x / uints_per_row`, so a warp can address at most `kWarpSize / uints_per_row` distinct bags. The host only enforced the shared-memory limit. On wave32 (RDNA, gfx1201) the trailing bags were never written, surfacing as NaNs in test_quantize_workflow (FP16/INT8/INT4 + MEAN, INT4 + SUM).

Use `kWarpSizeHost()` since `kWarpSize` is hardcoded to 64 in host code on ROCm.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Both following tests pass now.
`FBGEMM_TEST_WITH_ROCM=1 HIP_LAUNCH_BLOCKING=1 FBGEMM_TBE_ROCM_INFERENCE_PACKED_BAGS=1 pytest test/tbe/inference/inference_converter_test.py::QuantizedSplitEmbeddingsTest::test_quantize_workflow -v -x`

  The related fused-pooled-quant test

`FBGEMM_TEST_WITH_ROCM=1 HIP_LAUNCH_BLOCKING=1 FBGEMM_TBE_ROCM_INFERENCE_PACKED_BAGS=1 pytest test/tbe/inference/nbit_forward_test.py::NBitFowardTest::test_nbit_forward_fused_pooled_emb_quant -v -x`

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
