### PR TITLE
[ROCm] fix wave32 backward dropping gradients for embedding dims >= 128

### DIFF
--- a/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
+++ b/fbgemm_gpu/codegen/training/backward/embedding_backward_split_template.cu
@@ -383,10 +383,15 @@ using namespace embedding_ops;
 */
 #define DISPATCH_OPTIMAL_KERNEL(MAX_D, ...)                                     \
   [&] {                                                                         \
-    const int max_vecs_per_thread =                                             \
-      (max_D + {{ items_per_warp }} - 1) / {{ items_per_warp }};                \
     constexpr int kSubwarpDivisor = 1;                                          \
     const int kThreadGroupSize = kWarpSizeHost();                                 \
+    /* Derive max_vecs_per_thread from the runtime warp width (VEC_SIZE is the  \
+       Vec4TAcc width). A compile-time items_per_warp is baked to 256 on ROCm   \
+       and would drop dims >= 128 on wave32; this is correct on all archs. */   \
+    constexpr int VEC_SIZE = 4;                                                 \
+    const int max_vecs_per_thread =                                             \
+      (max_D + (kThreadGroupSize * VEC_SIZE) - 1)                               \
+      / (kThreadGroupSize * VEC_SIZE);                                          \
     constexpr int kFixedMaxVecsPerThread =                                      \
       {{ fixed_max_vecs_per_thread["backward"] }};                              \
     constexpr bool kUseVecBlocking = true;                                      \


### PR DESCRIPTION
The experimental-optimizer backward dispatch (DISPATCH_OPTIMAL_KERNEL) computed max_vecs_per_thread from the compile-time items_per_warp, which is baked to the wave64 value (256) on ROCm. On wave32 a thread group spans only kThreadGroupSize*4 = 128 elements per vec, so the wave64-derived vec count undercounts and the grad-sum loop never accumulates dims >= 128, zeroing those gradients.

Derive max_vecs_per_thread from the runtime warp width (kWarpSizeHost()*4). Identical to before on CUDA (128) and wave64 (256); correct on wave32. Fixes test_backward_optimizers_{lamb,lars,v1} on gfx1201.

## Motivation
Fix backward_optimizers issue on cards with wave=32.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan
passes tests on RX 9070 XT 
`pytest fbgemm_gpu/test/tbe/training/backward_optimizers_test.py`

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
