### PR TITLE
Fixes unit test failures by deriving nbit inference cache associativity from device warp size

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_inference.py
@@ -382,10 +382,6 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
             f"Feature Gates: {[(feature.name, feature.is_enabled()) for feature in FeatureGateName]}"
         )
 
-        # 64 for AMD
-        if cache_assoc == 32 and torch.version.hip is not None:
-            cache_assoc = 64
-
         if device is None:
             self.current_device: torch.device = torch.device(
                 torch.cuda.current_device()
@@ -395,6 +391,11 @@ class IntNBitTableBatchedEmbeddingBagsCodegen(nn.Module):
         else:
             self.current_device = torch.device(device)
         self.use_cpu: bool = self.current_device.type == "cpu"
+
+        if cache_assoc == 32 and not self.use_cpu:
+            cache_assoc = torch.cuda.get_device_properties(
+                self.current_device
+            ).warp_size
 
         self.scale_bias_size_in_bytes = scale_bias_size_in_bytes
         self.pooling_mode = pooling_mode

--- a/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
+++ b/fbgemm_gpu/fbgemm_gpu/split_table_batched_embeddings_ops_training.py
@@ -77,7 +77,9 @@ except Exception:
     pass
 
 
-DEFAULT_ASSOC = 32 if torch.version.hip is None else 64
+# Default cache associativity. Overridden to 64 in each module's
+# __init__ on AMD devices that have 64-lane waves.
+DEFAULT_ASSOC = 32
 INT8_EMB_ROW_DIM_OFFSET = 8
 
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/cache/cache_config.py
@@ -35,8 +35,9 @@ import torch
 # Import from config module
 from fbgemm_gpu.tbe.config import EmbeddingLocation
 
-# Default associativity for the UVM cache (32 for CUDA, 64 for ROCm)
-DEFAULT_ASSOC: int = 32 if torch.version.hip is None else 64
+# Default cache associativity. Overridden to 64 in each module's
+# __init__ on AMD devices that have 64-lane waves.
+DEFAULT_ASSOC: int = 32
 
 
 class CacheAlgorithm(enum.Enum):

--- a/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
+++ b/fbgemm_gpu/test/tbe/inference/nbit_cache_test.py
@@ -27,7 +27,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_common import (
 from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     IntNBitTableBatchedEmbeddingBagsCodegen,
 )
-from fbgemm_gpu.split_table_batched_embeddings_ops_training import DEFAULT_ASSOC
 from fbgemm_gpu.tbe.utils import get_table_batched_offsets_from_dense
 from hypothesis import given, settings, Verbosity
 
@@ -265,7 +264,7 @@ class NBitCacheTest(unittest.TestCase):
         )
         cc1.fill_random_weights()
 
-        associativty = DEFAULT_ASSOC  # 32 for NVidia / 64 for AMD.
+        associativty = cc1.cache_assoc
         repetition = 17
         indices1 = torch.Tensor(
             [[list(range(0, associativty))] * repetition]


### PR DESCRIPTION
 The nbit inference cache hardcoded associativity to 64 on ROCm, but the cache kernels scan one way per warp lane, so on wave32 (RDNA) half the ways were unreachable, corrupting UVM cache stats and codegen lookups.
 
This led to failures in the following unit tests:
 - `FBGEMM_TEST_WITH_ROCM=1 HIP_LAUNCH_BLOCKING=1 FBGEMM_TBE_ROCM_INFERENCE_PACKED_BAGS=1 pytest fbgemm_gpu/test/tbe/inference/nbit_cache_test.py::test_nbit_uvm_cache_stats`
 - `FBGEMM_TEST_WITH_ROCM=1 HIP_LAUNCH_BLOCKING=1 FBGEMM_TBE_ROCM_INFERENCE_PACKED_BAGS=1 pytest fbgemm_gpu/test/tbe/inference/nbit_split_embeddings_test.py::test_int_nbit_split_embedding_uvm_caching_codegen_lookup_function`
    
This PR derives `cache_assoc` from the device warp size instead, and make `DEFAULT_ASSOC` an unconditional 32 fallback.