### PR TITLE
fix ssd cache assoc wave32

### DIFF
--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
@@ -27,6 +27,17 @@ except Exception:
 ASSOC: int = 32
 
 
+def device_cache_assoc(use_cpu: bool = False) -> int:
+    """
+    Cache associativity for the current device: the warp size (32 on NVIDIA,
+    either 32 or 64 on AMD), since the C++ cache kernels use kWarpSize for set
+    indexing. Falls back to ASSOC when there is no device.
+    """
+    if use_cpu or not torch.cuda.is_available():
+        return ASSOC
+    return torch.cuda.get_device_properties(torch.cuda.current_device()).warp_size
+
+
 def pad4(value: int) -> int:
     """
     Compute the smallest multiple of 4 that is greater than or equal to the given value.

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
@@ -21,10 +21,9 @@ except Exception:
     pass
 
 # Cache associativity must match the hardware warp/wavefront width, since the
-# C++ cache kernels use kWarpSize for set indexing (one way per lane). The
-# device paths derive it from torch.cuda.get_device_properties(dev).warp_size
-# (32 on RDNA and NVIDIA, 64 on CDNA); this constant is only the no-device
-# fallback.
+# C++ cache kernels use kWarpSize for set indexing. The device paths derive
+# it from torch.cuda.get_device_properties(dev).warp_size (32 on NVIDIA,
+# either 32 or 64 on AMD); this constant is only the no-device fallback.
 ASSOC: int = 32
 
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/common.py
@@ -20,11 +20,12 @@ try:
 except Exception:
     pass
 
-# Match cache associativity to hardware warp/wavefront width:
-# NVIDIA warp = 32 lanes, AMD wavefront = 64 lanes.
-# C++ kernels use kWarpSize for cache set indexing, so Python-side
-# tensor shapes must agree.
-ASSOC: int = 32 if torch.version.hip is None else 64
+# Cache associativity must match the hardware warp/wavefront width, since the
+# C++ cache kernels use kWarpSize for set indexing (one way per lane). The
+# device paths derive it from torch.cuda.get_device_properties(dev).warp_size
+# (32 on RDNA and NVIDIA, 64 on CDNA); this constant is only the no-device
+# fallback.
+ASSOC: int = 32
 
 
 def pad4(value: int) -> int:

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -114,9 +114,9 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
 
     AMD/ROCm support status:
         This operator supports AMD GPUs (ROCm/HIP). Key adaptations:
-        - Cache associativity (ASSOC) is set to 64 to match AMD's 64-wide
-          wavefronts (vs. 32 for NVIDIA warps). Python-side tensor shapes
-          and C++ kernel indexing are kept in sync via common.ASSOC.
+        - Cache associativity is derived from the device warp size (64 on AMD
+          CDNA wavefronts, 32 on RDNA and NVIDIA warps), so Python-side tensor
+          shapes stay in sync with the C++ kernel's per-lane way indexing.
         - BitonicSort includes a 6th merge stage (L=32) for 64-element sorts.
         - lxu_cache_lookup uses HIP-native __ballot() instead of
           __ballot_sync().
@@ -137,7 +137,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         row_alignment: int | None = None,
         fp8_exponent_bits: int | None = None,
         fp8_exponent_bias: int | None = None,
-        cache_assoc: int = ASSOC,
+        cache_assoc: int | None = None,
         scale_bias_size_in_bytes: int = DEFAULT_SCALE_BIAS_SIZE_IN_BYTES,
         cache_sets: int = 0,
         ssd_storage_directory: str = "/tmp",
@@ -163,11 +163,6 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
     ) -> None:  # noqa C901  # tuple of (rows, dims,)
         super().__init__()
 
-        assert cache_assoc == ASSOC, (
-            f"cache_assoc must match platform ASSOC={ASSOC} "
-            f"(CUDA=32, ROCm=64), got {cache_assoc}"
-        )
-
         self.enable_cache_locking = enable_cache_locking
         self.scale_bias_size_in_bytes = scale_bias_size_in_bytes
         self.pooling_mode = pooling_mode
@@ -184,6 +179,18 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         else:
             self.current_device = torch.device(device)
         self.use_cpu: bool = self.current_device.type == "cpu"
+
+        # Cache associativity must equal the device warp size (64 on CDNA, 32 on
+        # RDNA and NVIDIA), as the cache kernels scan one way per warp lane.
+        if cache_assoc is None:
+            cache_assoc = (
+                ASSOC
+                if self.use_cpu
+                else torch.cuda.get_device_properties(
+                    self.current_device
+                ).warp_size
+            )
+        self.cache_assoc: int = cache_assoc
 
         self.feature_table_map: list[int] = (
             feature_table_map if feature_table_map is not None else list(range(T_))
@@ -288,7 +295,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         )
         assert cache_sets > 0
         element_size = 1
-        cache_size = cache_sets * ASSOC * element_size * self.max_D_cache
+        cache_size = cache_sets * self.cache_assoc * element_size * self.max_D_cache
         logging.info(
             f"Using cache for SSD with admission algorithm "
             f"{CacheAlgorithm.LRU}, {cache_sets} sets, stored on {'DEVICE' if ssd_cache_location is EmbeddingLocation.DEVICE else 'MANAGED'} with {ssd_shards} shards, "
@@ -301,10 +308,10 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         )
         self.register_buffer(
             "lxu_cache_state",
-            torch.zeros(cache_sets, ASSOC, dtype=torch.int64).fill_(-1),
+            torch.zeros(cache_sets, self.cache_assoc, dtype=torch.int64).fill_(-1),
         )
         self.register_buffer(
-            "lru_state", torch.zeros(cache_sets, ASSOC, dtype=torch.int64)
+            "lru_state", torch.zeros(cache_sets, self.cache_assoc, dtype=torch.int64)
         )
         # Cache locking counter: prevents eviction of cache lines that are
         # currently being read by forward(). Without this, a concurrent
@@ -313,7 +320,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             "lxu_cache_locking_counter",
             torch.zeros(
                 cache_sets,
-                ASSOC,
+                self.cache_assoc,
                 device=self.current_device,
                 dtype=torch.int32,
             ),
@@ -328,14 +335,14 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
                 "lxu_cache_weights",
                 torch.ops.fbgemm.new_managed_tensor(
                     torch.zeros(1, device=self.current_device, dtype=torch.uint8),
-                    [cache_sets * ASSOC, self.max_D_cache],
+                    [cache_sets * self.cache_assoc, self.max_D_cache],
                 ),
             )
         else:
             self.register_buffer(
                 "lxu_cache_weights",
                 torch.zeros(
-                    cache_sets * ASSOC,
+                    cache_sets * self.cache_assoc,
                     self.max_D_cache,
                     device=self.current_device,
                     dtype=torch.uint8,
@@ -472,9 +479,9 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
 
         if IS_ROCM:
             logging.info(
-                "SSD TBE inference running on ROCm with ASSOC=%d "
-                "(matching AMD 64-wide wavefronts).",
-                ASSOC,
+                "SSD TBE inference running on ROCm with cache associativity=%d "
+                "(matching the device warp size).",
+                self.cache_assoc,
             )
 
         # Read-write lock for concurrent inference + streaming updates.
@@ -775,17 +782,17 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         max_cache_sets = self.lxu_cache_state.shape[0]
         cache_set_ids = indices % max_cache_sets  # [N]
 
-        # Gather the ASSOC slots for each relevant cache set: [N, ASSOC]
+        # Gather the ways for each relevant cache set: [N, cache_assoc]
         relevant_states = self.lxu_cache_state[cache_set_ids]
 
-        # Find which slots hold the updated indices: [N, ASSOC] bool
+        # Find which slots hold the updated indices: [N, cache_assoc] bool
         matches = relevant_states == indices.unsqueeze(1)
 
         if matches.any():
             # Get (row_in_batch, slot) pairs for all matches
             n_idx, slot_idx = matches.nonzero(as_tuple=True)
             # Convert to flat indices into lxu_cache_state
-            flat_idx = cache_set_ids[n_idx] * ASSOC + slot_idx
+            flat_idx = cache_set_ids[n_idx] * self.cache_assoc + slot_idx
             self.lxu_cache_state.view(-1)[flat_idx] = -1
 
     @torch.jit.export

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -116,7 +116,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         This operator supports AMD GPUs (ROCm/HIP). Key adaptations:
         - Cache associativity is derived from the device warp size (32 on
           NVIDIA, either 32 or 64 on AMD), so Python-side tensor shapes
-          stay in sync with the C++ kernel's per-lane way indexing.
+          stay in sync with the C++ kernel's per-lane slot indexing.
         - BitonicSort includes a 6th merge stage (L=32) for 64-element sorts.
         - lxu_cache_lookup uses HIP-native __ballot() instead of
           __ballot_sync().
@@ -784,7 +784,7 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
         max_cache_sets = self.lxu_cache_state.shape[0]
         cache_set_ids = indices % max_cache_sets  # [N]
 
-        # Gather the ways for each relevant cache set: [N, cache_assoc]
+        # Gather the slots for each relevant cache set: [N, cache_assoc]
         relevant_states = self.lxu_cache_state[cache_set_ids]
 
         # Find which slots hold the updated indices: [N, cache_assoc] bool

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -114,9 +114,9 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
 
     AMD/ROCm support status:
         This operator supports AMD GPUs (ROCm/HIP). Key adaptations:
-        - Cache associativity is derived from the device warp size (64 on AMD
-          CDNA wavefronts, 32 on RDNA and NVIDIA warps), so Python-side tensor
-          shapes stay in sync with the C++ kernel's per-lane way indexing.
+        - Cache associativity is derived from the device warp size (32 on
+          NVIDIA, either 32 or 64 on AMD), so Python-side tensor shapes
+          stay in sync with the C++ kernel's per-lane way indexing.
         - BitonicSort includes a 6th merge stage (L=32) for 64-element sorts.
         - lxu_cache_lookup uses HIP-native __ballot() instead of
           __ballot_sync().
@@ -180,8 +180,6 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             self.current_device = torch.device(device)
         self.use_cpu: bool = self.current_device.type == "cpu"
 
-        # Cache associativity must equal the device warp size (64 on CDNA, 32 on
-        # RDNA and NVIDIA), as the cache kernels scan one way per warp lane.
         if cache_assoc is None:
             cache_assoc = (
                 ASSOC

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference.py
@@ -35,7 +35,7 @@ from fbgemm_gpu.tbe.config import (
 from torch import distributed as dist, nn, Tensor  # usort:skip
 from torch.autograd.profiler import record_function
 
-from .common import ASSOC
+from .common import device_cache_assoc
 
 IS_ROCM: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
 
@@ -180,13 +180,17 @@ class SSDIntNBitTableBatchedEmbeddingBags(nn.Module):
             self.current_device = torch.device(device)
         self.use_cpu: bool = self.current_device.type == "cpu"
 
+        # Cache associativity must equal the device warp size (32 on NVIDIA,
+        # either 32 or 64 on AMD). An explicit cache_assoc is honored only
+        # if it matches, so callers cannot silently request a mismatched
+        # (broken) geometry.
+        resolved_cache_assoc = device_cache_assoc(self.use_cpu)
         if cache_assoc is None:
-            cache_assoc = (
-                ASSOC
-                if self.use_cpu
-                else torch.cuda.get_device_properties(
-                    self.current_device
-                ).warp_size
+            cache_assoc = resolved_cache_assoc
+        elif cache_assoc != resolved_cache_assoc:
+            raise ValueError(
+                f"cache_assoc ({cache_assoc}) must equal the device warp size "
+                f"({resolved_cache_assoc})"
             )
         self.cache_assoc: int = cache_assoc
 

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -31,19 +31,8 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
 from fbgemm_gpu.tbe.config import PoolingMode
 from torch import nn, Tensor  # usort:skip
 
-from .common import ASSOC
+from .common import device_cache_assoc
 from .inference import SSDIntNBitTableBatchedEmbeddingBags
-
-
-def _device_cache_assoc() -> int:
-    # Cache associativity equals the device warp size (32 on NVIDIA, 
-    # either 32 or 64 on AMD). Fall back to ASSOC when no device is 
-    # available.
-    if torch.cuda.is_available():
-        return torch.cuda.get_device_properties(
-            torch.cuda.current_device()
-        ).warp_size
-    return ASSOC
 
 
 class TurboSSDInferenceModule(nn.Module):
@@ -137,7 +126,7 @@ class TurboSSDInferenceModule(nn.Module):
         module = cls(tbe)
 
         total_rows = sum(r for _, r, _, _ in specs)
-        cache_capacity = cache_sets * _device_cache_assoc()
+        cache_capacity = cache_sets * device_cache_assoc()
         logging.info(
             f"TurboSSD inference module: {len(specs)} tables, "
             f"{total_rows:,} total rows, "
@@ -162,7 +151,7 @@ class TurboSSDInferenceModule(nn.Module):
 
         If an HBM budget is specified, the cache is capped to fit within it.
         """
-        assoc = _device_cache_assoc()
+        assoc = device_cache_assoc()
         total_rows = sum(rows for _, rows, _, _ in specs)
         target_cached_rows = int(total_rows * cache_hit_rate)
         cache_sets_from_hit_rate = max((target_cached_rows + assoc - 1) // assoc, 1)
@@ -190,7 +179,7 @@ class TurboSSDInferenceModule(nn.Module):
         Returns the projected HBM cache size. Useful for capacity planning
         on H100 (96 GB) and MI350X (288 GB).
         """
-        assoc = _device_cache_assoc()
+        assoc = device_cache_assoc()
         total_rows = sum(rows for _, rows, _, _ in specs)
         target_rows = int(total_rows * cache_hit_rate)
         cache_sets = max((target_rows + assoc - 1) // assoc, 1)

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -36,8 +36,9 @@ from .inference import SSDIntNBitTableBatchedEmbeddingBags
 
 
 def _device_cache_assoc() -> int:
-    # Cache associativity equals the device warp size (64 on CDNA, 32 on RDNA
-    # and NVIDIA). Fall back to ASSOC when no device is available (planning).
+    # Cache associativity equals the device warp size (32 on NVIDIA, 
+    # either 32 or 64 on AMD). Fall back to ASSOC when no device is 
+    # available.
     if torch.cuda.is_available():
         return torch.cuda.get_device_properties(
             torch.cuda.current_device()

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -35,6 +35,16 @@ from .common import ASSOC
 from .inference import SSDIntNBitTableBatchedEmbeddingBags
 
 
+def _device_cache_assoc() -> int:
+    # Cache associativity equals the device warp size (64 on CDNA, 32 on RDNA
+    # and NVIDIA). Fall back to ASSOC when no device is available (planning).
+    if torch.cuda.is_available():
+        return torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).warp_size
+    return ASSOC
+
+
 class TurboSSDInferenceModule(nn.Module):
     """
     Drop-in serving module backed by FBGEMM SSD TBE with TurboSSD v2
@@ -126,7 +136,7 @@ class TurboSSDInferenceModule(nn.Module):
         module = cls(tbe)
 
         total_rows = sum(r for _, r, _, _ in specs)
-        cache_capacity = cache_sets * ASSOC
+        cache_capacity = cache_sets * _device_cache_assoc()
         logging.info(
             f"TurboSSD inference module: {len(specs)} tables, "
             f"{total_rows:,} total rows, "
@@ -145,23 +155,23 @@ class TurboSSDInferenceModule(nn.Module):
         """
         Compute the number of cache sets for the target hit rate.
 
-        For a set-associative cache with ASSOC ways, we need enough sets
+        For a set-associative cache with `assoc` ways, we need enough sets
         so that the total number of cache slots >= target fraction of the
         working set.
 
         If an HBM budget is specified, the cache is capped to fit within it.
         """
-
+        assoc = _device_cache_assoc()
         total_rows = sum(rows for _, rows, _, _ in specs)
         target_cached_rows = int(total_rows * cache_hit_rate)
-        cache_sets_from_hit_rate = max((target_cached_rows + ASSOC - 1) // ASSOC, 1)
+        cache_sets_from_hit_rate = max((target_cached_rows + assoc - 1) // assoc, 1)
 
         if hbm_budget_gb > 0:
             max_d_cache = max(
                 rounded_row_size_in_bytes(dim, ty, 16) for _, _, dim, ty in specs
             )
             budget_bytes = int(hbm_budget_gb * 1024 * 1024 * 1024)
-            cache_sets_from_budget = budget_bytes // (ASSOC * max_d_cache)
+            cache_sets_from_budget = budget_bytes // (assoc * max_d_cache)
             cache_sets = min(cache_sets_from_hit_rate, max(cache_sets_from_budget, 1))
         else:
             cache_sets = cache_sets_from_hit_rate
@@ -179,14 +189,15 @@ class TurboSSDInferenceModule(nn.Module):
         Returns the projected HBM cache size. Useful for capacity planning
         on H100 (96 GB) and MI350X (288 GB).
         """
+        assoc = _device_cache_assoc()
         total_rows = sum(rows for _, rows, _, _ in specs)
         target_rows = int(total_rows * cache_hit_rate)
-        cache_sets = max((target_rows + ASSOC - 1) // ASSOC, 1)
+        cache_sets = max((target_rows + assoc - 1) // assoc, 1)
 
         max_d_cache = max(
             rounded_row_size_in_bytes(dim, ty, 16) for _, _, dim, ty in specs
         )
-        cache_bytes = cache_sets * ASSOC * max_d_cache
+        cache_bytes = cache_sets * assoc * max_d_cache
         return cache_bytes / (1024 * 1024 * 1024)
 
     def forward(

--- a/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
+++ b/fbgemm_gpu/fbgemm_gpu/tbe/ssd/inference_serving.py
@@ -145,8 +145,8 @@ class TurboSSDInferenceModule(nn.Module):
         """
         Compute the number of cache sets for the target hit rate.
 
-        For a set-associative cache with `assoc` ways, we need enough sets
-        so that the total number of cache slots >= target fraction of the
+        For a set-associative cache with `assoc` slots per set, we need enough
+        sets so that the total number of cache slots >= target fraction of the
         working set.
 
         If an HBM budget is specified, the cache is capped to fit within it.

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -1537,7 +1537,7 @@ class TurboSSDInferenceModuleTest(unittest.TestCase):
             hbm_budget_gb=0.1,
             cache_hit_rate=0.90,
         )
-        cache_slots = module.tbe.lxu_cache_state.numel()
+        cache_slots = module.tbe.lxu_cache_state.shape[0] * module.tbe.cache_assoc
         # 0.1 GB = ~107 million bytes. With ~512 bytes/row, ~209K rows max.
         self.assertLess(cache_slots, 1_000_000)
 

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -10,6 +10,7 @@
 import random
 import time
 import unittest
+from unittest.mock import patch
 
 import hypothesis.strategies as st
 import numpy as np
@@ -2000,13 +2001,12 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             emb.lxu_cache_weights.shape[0], cache_sets * emb.cache_assoc
         )
 
-    # ─── Explicit assoc=64 tests (exercise 64-wide cache on any device) ──
+    # ─── Simulated assoc=64 tests (exercise 64-wide cache on any device) ──
 
     def test_invalidate_cache_explicit_assoc64(self) -> None:
         """
-        Construct with an explicit cache_assoc=64 so the wider cache can be
-        exercised on any device. Verifies _invalidate_cache works for 64-wide
-        cache sets.
+        Simulate a 64-wide warp so the wider cache can be exercised on any
+        device. Verifies _invalidate_cache works for 64-wide cache sets.
         """
         import tempfile
 
@@ -2015,14 +2015,17 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         cache_sets = 16
         assoc = 64
 
-        emb = SSDIntNBitTableBatchedEmbeddingBags(
-            embedding_specs=[("", E, D, SparseType.FP32)],
-            feature_table_map=[0],
-            ssd_storage_directory=tempfile.mkdtemp(),
-            cache_sets=cache_sets,
-            cache_assoc=assoc,
-            pooling_mode=PoolingMode.SUM,
-        ).cuda()
+        with patch(
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+        ):
+            emb = SSDIntNBitTableBatchedEmbeddingBags(
+                embedding_specs=[("", E, D, SparseType.FP32)],
+                feature_table_map=[0],
+                ssd_storage_directory=tempfile.mkdtemp(),
+                cache_sets=cache_sets,
+                cache_assoc=assoc,
+                pooling_mode=PoolingMode.SUM,
+            ).cuda()
 
         # Verify shapes
         self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, assoc))
@@ -2052,14 +2055,17 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         cache_sets = 8
         assoc = 64
 
-        emb = SSDIntNBitTableBatchedEmbeddingBags(
-            embedding_specs=[("", E, D, SparseType.FP32)],
-            feature_table_map=[0],
-            ssd_storage_directory=tempfile.mkdtemp(),
-            cache_sets=cache_sets,
-            cache_assoc=assoc,
-            pooling_mode=PoolingMode.SUM,
-        ).cuda()
+        with patch(
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+        ):
+            emb = SSDIntNBitTableBatchedEmbeddingBags(
+                embedding_specs=[("", E, D, SparseType.FP32)],
+                feature_table_map=[0],
+                ssd_storage_directory=tempfile.mkdtemp(),
+                cache_sets=cache_sets,
+                cache_assoc=assoc,
+                pooling_mode=PoolingMode.SUM,
+            ).cuda()
 
         # Place entry at (set=7, slot=63) — the very last position
         last_set = cache_sets - 1
@@ -2094,14 +2100,17 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         cache_sets = 16
         assoc = 64
 
-        emb = SSDIntNBitTableBatchedEmbeddingBags(
-            embedding_specs=[("", E, D, SparseType.FP32)],
-            feature_table_map=[0],
-            ssd_storage_directory=tempfile.mkdtemp(),
-            cache_sets=cache_sets,
-            cache_assoc=assoc,
-            pooling_mode=PoolingMode.SUM,
-        ).cuda()
+        with patch(
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+        ):
+            emb = SSDIntNBitTableBatchedEmbeddingBags(
+                embedding_specs=[("", E, D, SparseType.FP32)],
+                feature_table_map=[0],
+                ssd_storage_directory=tempfile.mkdtemp(),
+                cache_sets=cache_sets,
+                cache_assoc=assoc,
+                pooling_mode=PoolingMode.SUM,
+            ).cuda()
 
         # Populate 3 entries in different sets, using various slots
         entries = [
@@ -2130,22 +2139,20 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 class SSDInferenceAssocWarpSizeTest(unittest.TestCase):
     """
     The SSD inference cache associativity must equal the device warp size: the
-    cache kernels use kWarpSize for set indexing, scanning one way per lane. On
-    wave32 (RDNA) devices a hardcoded associativity of 64 makes the host
-    allocate 64-way sets that the kernel only half-scans. Unlike the rest of the
-    SSD tests, this does not need the RocksDB backend, so it runs in OSS.
+    cache kernels use kWarpSize for set indexing, scanning one way per lane.
+    Unlike the rest of the SSD tests, this does not need the RocksDB backend,
+    so it runs in OSS.
     """
 
-    def test_serving_compute_cache_sets_uses_device_warp_size(self) -> None:
-        from fbgemm_gpu.tbe.ssd.inference_serving import _device_cache_assoc
+    def test_device_cache_assoc_matches_warp_size(self) -> None:
+        from fbgemm_gpu.tbe.ssd.common import device_cache_assoc
 
         warp_size = torch.cuda.get_device_properties(
             torch.cuda.current_device()
         ).warp_size
         self.assertEqual(
-            _device_cache_assoc(),
+            device_cache_assoc(),
             warp_size,
-            f"SSD serving associativity ({_device_cache_assoc()}) must equal the "
-            f"device warp size ({warp_size}); the cache kernels scan one way per "
-            "warp lane.",
+            f"SSD cache associativity ({device_cache_assoc()}) must equal the "
+            f"device warp size ({warp_size})."
         )

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -1695,7 +1695,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             emb.cache_assoc,
             warp_size,
             f"cache_assoc ({emb.cache_assoc}) must equal the device warp size "
-            f"({warp_size}); the cache kernels scan one way per warp lane.",
+            f"({warp_size}).",
         )
 
     def test_cache_assoc_is_power_of_two(self) -> None:
@@ -1781,7 +1781,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         )
 
     def test_invalidate_cache_last_slot(self) -> None:
-        """Cache invalidation must work in the last way (slot cache_assoc-1)."""
+        """Cache invalidation must work in the last slot of a set (cache_assoc-1)."""
         E = 1000
         D = 128
         cache_sets = 64
@@ -1802,7 +1802,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 
     def test_invalidate_cache_all_slots_populated(self) -> None:
         """
-        When all ways in a cache set are populated, invalidation
+        When all slots in a cache set are populated, invalidation
         should only clear the matching entry.
         """
         E = 10000
@@ -1810,7 +1810,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         cache_sets = 128
         emb = self._create_emb(E=E, D=D, cache_sets=cache_sets)
 
-        # Fill all ways in set 0 with distinct indices that all
+        # Fill all slots in set 0 with distinct indices that all
         # map to set 0 (i.e., index % cache_sets == 0).
         target_set = 0
         indices_in_set = [i * cache_sets for i in range(emb.cache_assoc)]
@@ -2001,37 +2001,39 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             emb.lxu_cache_weights.shape[0], cache_sets * emb.cache_assoc
         )
 
-    # ─── Simulated assoc=64 tests (exercise 64-wide cache on any device) ──
+    # ─── Simulated ASSOC=64 tests (run on NVIDIA to test the logic) ──────
 
-    def test_invalidate_cache_explicit_assoc64(self) -> None:
+    def test_invalidate_cache_simulated_assoc64(self) -> None:
         """
-        Simulate a 64-wide warp so the wider cache can be exercised on any
-        device. Verifies _invalidate_cache works for 64-wide cache sets.
+        Simulate ASSOC=64 on NVIDIA hardware by patching device_cache_assoc
+        and creating a module with the wider cache. This verifies the
+        _invalidate_cache logic works for 64-wide cache sets.
         """
         import tempfile
 
         E = 1000
         D = 64
         cache_sets = 16
-        assoc = 64
+        sim_assoc = 64
 
+        # Create with simulated ASSOC=64
         with patch(
-            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=sim_assoc
         ):
             emb = SSDIntNBitTableBatchedEmbeddingBags(
                 embedding_specs=[("", E, D, SparseType.FP32)],
                 feature_table_map=[0],
                 ssd_storage_directory=tempfile.mkdtemp(),
                 cache_sets=cache_sets,
-                cache_assoc=assoc,
+                cache_assoc=sim_assoc,
                 pooling_mode=PoolingMode.SUM,
             ).cuda()
 
         # Verify shapes
-        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, assoc))
-        self.assertEqual(emb.lxu_cache_weights.shape[0], cache_sets * assoc)
+        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, sim_assoc))
+        self.assertEqual(emb.lxu_cache_weights.shape[0], cache_sets * sim_assoc)
 
-        # Place an entry in slot 63 (only valid with assoc=64)
+        # Place an entry in slot 63 (only valid with ASSOC=64)
         target_set = 5
         emb.lxu_cache_state[target_set, 63] = 5
 
@@ -2040,12 +2042,12 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         self.assertEqual(
             emb.lxu_cache_state[target_set, 63].item(),
             -1,
-            "Slot 63 should be invalidated with assoc=64",
+            "Slot 63 should be invalidated with ASSOC=64",
         )
 
-    def test_invalidate_cache_explicit_assoc64_boundary(self) -> None:
+    def test_invalidate_cache_simulated_assoc64_boundary(self) -> None:
         """
-        With cache_assoc=64, verify flat index computation at boundary:
+        With ASSOC=64, verify flat index computation at boundary:
         (last_set, last_slot) should produce correct flat_idx.
         """
         import tempfile
@@ -2053,27 +2055,27 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         E = 10000
         D = 64
         cache_sets = 8
-        assoc = 64
+        sim_assoc = 64
 
         with patch(
-            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=sim_assoc
         ):
             emb = SSDIntNBitTableBatchedEmbeddingBags(
                 embedding_specs=[("", E, D, SparseType.FP32)],
                 feature_table_map=[0],
                 ssd_storage_directory=tempfile.mkdtemp(),
                 cache_sets=cache_sets,
-                cache_assoc=assoc,
+                cache_assoc=sim_assoc,
                 pooling_mode=PoolingMode.SUM,
             ).cuda()
 
         # Place entry at (set=7, slot=63) — the very last position
         last_set = cache_sets - 1
-        last_slot = assoc - 1
+        last_slot = sim_assoc - 1
         idx = last_set  # maps to set = 7 % 8 = 7
         emb.lxu_cache_state[last_set, last_slot] = idx
 
-        expected_flat_idx = last_set * assoc + last_slot  # 7*64+63 = 511
+        expected_flat_idx = last_set * sim_assoc + last_slot  # 7*64+63 = 511
         # Verify the flat view
         self.assertEqual(
             emb.lxu_cache_state.view(-1)[expected_flat_idx].item(),
@@ -2088,9 +2090,9 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             f"Flat index {expected_flat_idx} should be invalidated",
         )
 
-    def test_invalidate_cache_explicit_assoc64_multi_match(self) -> None:
+    def test_invalidate_cache_simulated_assoc64_multi_match(self) -> None:
         """
-        With cache_assoc=64, test that invalidation of a batch of indices
+        With ASSOC=64, test that invalidation of a batch of indices
         correctly handles multiple matches across different cache sets.
         """
         import tempfile
@@ -2098,17 +2100,17 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         E = 10000
         D = 64
         cache_sets = 16
-        assoc = 64
+        sim_assoc = 64
 
         with patch(
-            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=assoc
+            "fbgemm_gpu.tbe.ssd.inference.device_cache_assoc", return_value=sim_assoc
         ):
             emb = SSDIntNBitTableBatchedEmbeddingBags(
                 embedding_specs=[("", E, D, SparseType.FP32)],
                 feature_table_map=[0],
                 ssd_storage_directory=tempfile.mkdtemp(),
                 cache_sets=cache_sets,
-                cache_assoc=assoc,
+                cache_assoc=sim_assoc,
                 pooling_mode=PoolingMode.SUM,
             ).cuda()
 
@@ -2139,7 +2141,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 class SSDInferenceAssocWarpSizeTest(unittest.TestCase):
     """
     The SSD inference cache associativity must equal the device warp size: the
-    cache kernels use kWarpSize for set indexing, scanning one way per lane.
+    cache kernels use kWarpSize for set indexing, scanning one slot per lane.
     Unlike the rest of the SSD tests, this does not need the RocksDB backend,
     so it runs in OSS.
     """

--- a/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
+++ b/fbgemm_gpu/test/tbe/ssd/ssd_split_tbe_inference_test.py
@@ -10,7 +10,6 @@
 import random
 import time
 import unittest
-from unittest.mock import patch
 
 import hypothesis.strategies as st
 import numpy as np
@@ -25,7 +24,6 @@ from fbgemm_gpu.split_table_batched_embeddings_ops_inference import (
     unpadded_row_size_in_bytes,
 )
 from fbgemm_gpu.tbe.ssd import SSDIntNBitTableBatchedEmbeddingBags
-from fbgemm_gpu.tbe.ssd.common import ASSOC
 from fbgemm_gpu.tbe.utils import (
     b_indices,
     fake_quantize_embs,
@@ -411,7 +409,7 @@ class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
             lxu_cache_state_cpu = emb.lxu_cache_state.cpu()
 
             NOT_FOUND = np.iinfo(np.int32).max
-            ASSOC = 32
+            assoc = emb.cache_assoc
 
             for loc, linear_idx in zip(
                 lxu_cache_locations.cpu().numpy().tolist(),
@@ -419,8 +417,8 @@ class SSDIntNBitTableBatchedEmbeddingsTest(unittest.TestCase):
             ):
                 assert loc != NOT_FOUND
                 # if we have a hit, check the cache is consistent
-                loc_set = loc // ASSOC
-                loc_slot = loc % ASSOC
+                loc_set = loc // assoc
+                loc_slot = loc % assoc
                 assert lru_state_cpu[loc_set, loc_slot] == emb.timestep_counter.get()
                 assert lxu_cache_state_cpu[loc_set, loc_slot] == linear_idx
             fs = (
@@ -461,14 +459,13 @@ class SSDInferenceCacheLockingTest(unittest.TestCase):
     def test_lxu_cache_locking_counter_registered(self) -> None:
         """
         Test D96632292: Verify lxu_cache_locking_counter buffer is registered
-        with correct shape (cache_sets, ASSOC) and dtype int32.
+        with correct shape (cache_sets, cache_assoc) and dtype int32.
         """
         import tempfile
 
         E = int(1e4)
         D = 128
         cache_sets = 64
-        ASSOC = 32  # hardcoded in FBGEMM
 
         emb = SSDIntNBitTableBatchedEmbeddingBags(
             embedding_specs=[("", E, D, SparseType.FP32)],
@@ -486,8 +483,8 @@ class SSDInferenceCacheLockingTest(unittest.TestCase):
         )
         self.assertEqual(
             emb.lxu_cache_locking_counter.shape,
-            (cache_sets, ASSOC),
-            f"Expected shape ({cache_sets}, {ASSOC}), "
+            (cache_sets, emb.cache_assoc),
+            f"Expected shape ({cache_sets}, {emb.cache_assoc}), "
             f"got {emb.lxu_cache_locking_counter.shape}",
         )
         self.assertEqual(
@@ -1539,7 +1536,7 @@ class TurboSSDInferenceModuleTest(unittest.TestCase):
             hbm_budget_gb=0.1,
             cache_hit_rate=0.90,
         )
-        cache_slots = module.tbe.lxu_cache_state.shape[0] * ASSOC
+        cache_slots = module.tbe.lxu_cache_state.numel()
         # 0.1 GB = ~107 million bytes. With ~512 bytes/row, ~209K rows max.
         self.assertLess(cache_slots, 1_000_000)
 
@@ -1639,14 +1636,12 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
     Tests for AMD/ROCm support in SSD TBE inference.
 
     These tests verify:
-    - ASSOC constant matches the platform warp/wavefront width
-    - Tensor shapes use the platform-appropriate ASSOC
-    - Cache invalidation works correctly with any ASSOC value
-    - Forward pass is correct regardless of ASSOC
+    - Cache associativity matches the device warp/wavefront width
+    - Tensor shapes use the device-derived associativity
+    - Cache invalidation works correctly at any associativity
+    - Forward pass is correct regardless of associativity
     - The full prefetch+forward pipeline works end-to-end
     """
-
-    IS_ROCM: bool = hasattr(torch.version, "hip") and torch.version.hip is not None
 
     def _create_emb(
         self,
@@ -1687,53 +1682,63 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         torch.cuda.synchronize()
         return weights
 
-    # ─── ASSOC constant tests ────────────────────────────────────────────
+    # ─── Cache associativity tests ───────────────────────────────────────
 
-    def test_assoc_value_matches_platform(self) -> None:
-        """ASSOC should be 64 on ROCm, 32 on CUDA."""
-        if self.IS_ROCM:
-            self.assertEqual(ASSOC, 64, "ASSOC must be 64 on ROCm (64-wide wavefronts)")
-        else:
-            self.assertEqual(ASSOC, 32, "ASSOC must be 32 on CUDA (32-wide warps)")
+    def test_cache_assoc_matches_device_warp_size(self) -> None:
+        """Cache associativity must equal the device warp size."""
+        warp_size = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).warp_size
+        emb = self._create_emb(cache_sets=64)
+        self.assertEqual(
+            emb.cache_assoc,
+            warp_size,
+            f"cache_assoc ({emb.cache_assoc}) must equal the device warp size "
+            f"({warp_size}); the cache kernels scan one way per warp lane.",
+        )
 
-    def test_assoc_is_power_of_two(self) -> None:
-        """ASSOC must be a power of 2 for set-associative cache indexing."""
+    def test_cache_assoc_is_power_of_two(self) -> None:
+        """Cache associativity must be a power of 2 for set indexing."""
+        emb = self._create_emb(cache_sets=64)
+        assoc = emb.cache_assoc
         self.assertTrue(
-            ASSOC > 0 and (ASSOC & (ASSOC - 1)) == 0,
-            f"ASSOC={ASSOC} is not a power of 2",
+            assoc > 0 and (assoc & (assoc - 1)) == 0,
+            f"cache_assoc={assoc} is not a power of 2",
         )
 
     # ─── Tensor shape tests ──────────────────────────────────────────────
 
     def test_lxu_cache_state_shape(self) -> None:
-        """lxu_cache_state must have ASSOC columns."""
+        """lxu_cache_state must have cache_assoc columns."""
         cache_sets = 128
         emb = self._create_emb(cache_sets=cache_sets)
         self.assertEqual(
             emb.lxu_cache_state.shape,
-            (cache_sets, ASSOC),
-            f"lxu_cache_state shape mismatch: expected ({cache_sets}, {ASSOC})",
+            (cache_sets, emb.cache_assoc),
+            f"lxu_cache_state shape mismatch: expected ({cache_sets}, {emb.cache_assoc})",
         )
 
     def test_lru_state_shape(self) -> None:
-        """lru_state must have ASSOC columns."""
+        """lru_state must have cache_assoc columns."""
         cache_sets = 64
         emb = self._create_emb(cache_sets=cache_sets)
-        self.assertEqual(emb.lru_state.shape, (cache_sets, ASSOC))
+        self.assertEqual(emb.lru_state.shape, (cache_sets, emb.cache_assoc))
 
     def test_lxu_cache_locking_counter_shape(self) -> None:
-        """lxu_cache_locking_counter must have ASSOC columns."""
+        """lxu_cache_locking_counter must have cache_assoc columns."""
         cache_sets = 64
         emb = self._create_emb(cache_sets=cache_sets)
-        self.assertEqual(emb.lxu_cache_locking_counter.shape, (cache_sets, ASSOC))
+        self.assertEqual(
+            emb.lxu_cache_locking_counter.shape, (cache_sets, emb.cache_assoc)
+        )
 
     def test_lxu_cache_weights_shape(self) -> None:
-        """lxu_cache_weights rows = cache_sets * ASSOC."""
+        """lxu_cache_weights rows = cache_sets * cache_assoc."""
         cache_sets = 32
         D = 128
         weights_ty = SparseType.FP32
         emb = self._create_emb(cache_sets=cache_sets, D=D, weights_ty=weights_ty)
-        expected_rows = cache_sets * ASSOC
+        expected_rows = cache_sets * emb.cache_assoc
         self.assertEqual(
             emb.lxu_cache_weights.shape[0],
             expected_rows,
@@ -1775,7 +1780,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         )
 
     def test_invalidate_cache_last_slot(self) -> None:
-        """Cache invalidation must work in the last ASSOC slot (slot ASSOC-1)."""
+        """Cache invalidation must work in the last way (slot cache_assoc-1)."""
         E = 1000
         D = 128
         cache_sets = 64
@@ -1783,7 +1788,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 
         # Place index 7 in the LAST slot of its cache set
         target_set = 7 % cache_sets
-        last_slot = ASSOC - 1
+        last_slot = emb.cache_assoc - 1
         emb.lxu_cache_state[target_set, last_slot] = 7
 
         emb._invalidate_cache(torch.tensor([7], dtype=torch.int64))
@@ -1796,7 +1801,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 
     def test_invalidate_cache_all_slots_populated(self) -> None:
         """
-        When all ASSOC slots in a cache set are populated, invalidation
+        When all ways in a cache set are populated, invalidation
         should only clear the matching entry.
         """
         E = 10000
@@ -1804,21 +1809,21 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         cache_sets = 128
         emb = self._create_emb(E=E, D=D, cache_sets=cache_sets)
 
-        # Fill all ASSOC slots in set 0 with distinct indices that all
+        # Fill all ways in set 0 with distinct indices that all
         # map to set 0 (i.e., index % cache_sets == 0).
         target_set = 0
-        indices_in_set = [i * cache_sets for i in range(ASSOC)]
+        indices_in_set = [i * cache_sets for i in range(emb.cache_assoc)]
         for slot, idx in enumerate(indices_in_set):
             emb.lxu_cache_state[target_set, slot] = idx
 
         # Invalidate only the index in the middle slot
-        mid_slot = ASSOC // 2
+        mid_slot = emb.cache_assoc // 2
         mid_idx = indices_in_set[mid_slot]
         emb._invalidate_cache(torch.tensor([mid_idx], dtype=torch.int64))
 
         # Middle slot should be -1, others unchanged
         self.assertEqual(emb.lxu_cache_state[target_set, mid_slot].item(), -1)
-        for slot in range(ASSOC):
+        for slot in range(emb.cache_assoc):
             if slot != mid_slot:
                 self.assertEqual(
                     emb.lxu_cache_state[target_set, slot].item(),
@@ -1828,8 +1833,8 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
 
     def test_invalidate_cache_flat_index_correctness(self) -> None:
         """
-        The flat index computation (cache_set * ASSOC + slot) must be correct
-        for the platform's ASSOC value.
+        The flat index computation (cache_set * cache_assoc + slot) must be
+        correct for the device's cache associativity.
         """
         E = 10000
         D = 64
@@ -1837,12 +1842,13 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         emb = self._create_emb(E=E, D=D, cache_sets=cache_sets)
 
         # Place entries in various (set, slot) positions
+        assoc = emb.cache_assoc
         test_cases = [
             (0, 0),
-            (0, ASSOC - 1),
+            (0, assoc - 1),
             (cache_sets - 1, 0),
-            (cache_sets - 1, ASSOC - 1),
-            (cache_sets // 2, ASSOC // 2),
+            (cache_sets - 1, assoc - 1),
+            (cache_sets // 2, assoc // 2),
         ]
         for cache_set, slot in test_cases:
             idx = cache_set  # index % cache_sets == cache_set
@@ -1983,63 +1989,60 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
     # ─── Multi-table with platform ASSOC ─────────────────────────────────
 
     def test_multi_table_tensor_shapes(self) -> None:
-        """Multi-table setup should share the same cache with ASSOC slots."""
+        """Multi-table setup should share the same cache with cache_assoc slots."""
         T = 3
         cache_sets = 32
         emb = self._create_emb(T=T, cache_sets=cache_sets)
 
         # Cache state is shared across all tables
-        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, ASSOC))
-        self.assertEqual(emb.lxu_cache_weights.shape[0], cache_sets * ASSOC)
+        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, emb.cache_assoc))
+        self.assertEqual(
+            emb.lxu_cache_weights.shape[0], cache_sets * emb.cache_assoc
+        )
 
-    # ─── Simulated ASSOC=64 tests (run on NVIDIA to test the logic) ──────
+    # ─── Explicit assoc=64 tests (exercise 64-wide cache on any device) ──
 
-    def test_invalidate_cache_simulated_assoc64(self) -> None:
+    def test_invalidate_cache_explicit_assoc64(self) -> None:
         """
-        Simulate ASSOC=64 on NVIDIA hardware by patching the common.ASSOC
-        and creating a module with the wider cache. This verifies the
-        _invalidate_cache logic works for 64-wide cache sets.
+        Construct with an explicit cache_assoc=64 so the wider cache can be
+        exercised on any device. Verifies _invalidate_cache works for 64-wide
+        cache sets.
         """
         import tempfile
 
         E = 1000
         D = 64
         cache_sets = 16
-        sim_assoc = 64
+        assoc = 64
 
-        # Create with simulated ASSOC=64
-        with patch("fbgemm_gpu.tbe.ssd.common.ASSOC", sim_assoc), patch(
-            "fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc
-        ):
-            emb = SSDIntNBitTableBatchedEmbeddingBags(
-                embedding_specs=[("", E, D, SparseType.FP32)],
-                feature_table_map=[0],
-                ssd_storage_directory=tempfile.mkdtemp(),
-                cache_sets=cache_sets,
-                cache_assoc=sim_assoc,
-                pooling_mode=PoolingMode.SUM,
-            ).cuda()
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            cache_assoc=assoc,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
 
         # Verify shapes
-        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, sim_assoc))
-        self.assertEqual(emb.lxu_cache_weights.shape[0], cache_sets * sim_assoc)
+        self.assertEqual(emb.lxu_cache_state.shape, (cache_sets, assoc))
+        self.assertEqual(emb.lxu_cache_weights.shape[0], cache_sets * assoc)
 
-        # Place an entry in slot 63 (only valid with ASSOC=64)
+        # Place an entry in slot 63 (only valid with assoc=64)
         target_set = 5
         emb.lxu_cache_state[target_set, 63] = 5
 
-        with patch("fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc):
-            emb._invalidate_cache(torch.tensor([5], dtype=torch.int64))
+        emb._invalidate_cache(torch.tensor([5], dtype=torch.int64))
 
         self.assertEqual(
             emb.lxu_cache_state[target_set, 63].item(),
             -1,
-            "Slot 63 should be invalidated with ASSOC=64",
+            "Slot 63 should be invalidated with assoc=64",
         )
 
-    def test_invalidate_cache_simulated_assoc64_boundary(self) -> None:
+    def test_invalidate_cache_explicit_assoc64_boundary(self) -> None:
         """
-        With ASSOC=64, verify flat index computation at boundary:
+        With cache_assoc=64, verify flat index computation at boundary:
         (last_set, last_slot) should produce correct flat_idx.
         """
         import tempfile
@@ -2047,35 +2050,31 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         E = 10000
         D = 64
         cache_sets = 8
-        sim_assoc = 64
+        assoc = 64
 
-        with patch("fbgemm_gpu.tbe.ssd.common.ASSOC", sim_assoc), patch(
-            "fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc
-        ):
-            emb = SSDIntNBitTableBatchedEmbeddingBags(
-                embedding_specs=[("", E, D, SparseType.FP32)],
-                feature_table_map=[0],
-                ssd_storage_directory=tempfile.mkdtemp(),
-                cache_sets=cache_sets,
-                cache_assoc=sim_assoc,
-                pooling_mode=PoolingMode.SUM,
-            ).cuda()
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            cache_assoc=assoc,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
 
         # Place entry at (set=7, slot=63) — the very last position
         last_set = cache_sets - 1
-        last_slot = sim_assoc - 1
+        last_slot = assoc - 1
         idx = last_set  # maps to set = 7 % 8 = 7
         emb.lxu_cache_state[last_set, last_slot] = idx
 
-        expected_flat_idx = last_set * sim_assoc + last_slot  # 7*64+63 = 511
+        expected_flat_idx = last_set * assoc + last_slot  # 7*64+63 = 511
         # Verify the flat view
         self.assertEqual(
             emb.lxu_cache_state.view(-1)[expected_flat_idx].item(),
             idx,
         )
 
-        with patch("fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc):
-            emb._invalidate_cache(torch.tensor([idx], dtype=torch.int64))
+        emb._invalidate_cache(torch.tensor([idx], dtype=torch.int64))
 
         self.assertEqual(
             emb.lxu_cache_state.view(-1)[expected_flat_idx].item(),
@@ -2083,9 +2082,9 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             f"Flat index {expected_flat_idx} should be invalidated",
         )
 
-    def test_invalidate_cache_simulated_assoc64_multi_match(self) -> None:
+    def test_invalidate_cache_explicit_assoc64_multi_match(self) -> None:
         """
-        With ASSOC=64, test that invalidation of a batch of indices
+        With cache_assoc=64, test that invalidation of a batch of indices
         correctly handles multiple matches across different cache sets.
         """
         import tempfile
@@ -2093,19 +2092,16 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
         E = 10000
         D = 64
         cache_sets = 16
-        sim_assoc = 64
+        assoc = 64
 
-        with patch("fbgemm_gpu.tbe.ssd.common.ASSOC", sim_assoc), patch(
-            "fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc
-        ):
-            emb = SSDIntNBitTableBatchedEmbeddingBags(
-                embedding_specs=[("", E, D, SparseType.FP32)],
-                feature_table_map=[0],
-                ssd_storage_directory=tempfile.mkdtemp(),
-                cache_sets=cache_sets,
-                cache_assoc=sim_assoc,
-                pooling_mode=PoolingMode.SUM,
-            ).cuda()
+        emb = SSDIntNBitTableBatchedEmbeddingBags(
+            embedding_specs=[("", E, D, SparseType.FP32)],
+            feature_table_map=[0],
+            ssd_storage_directory=tempfile.mkdtemp(),
+            cache_sets=cache_sets,
+            cache_assoc=assoc,
+            pooling_mode=PoolingMode.SUM,
+        ).cuda()
 
         # Populate 3 entries in different sets, using various slots
         entries = [
@@ -2120,8 +2116,7 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
             [e[2] for e in entries],
             dtype=torch.int64,
         )
-        with patch("fbgemm_gpu.tbe.ssd.inference.ASSOC", sim_assoc):
-            emb._invalidate_cache(indices_to_invalidate)
+        emb._invalidate_cache(indices_to_invalidate)
 
         for target_set, slot, idx in entries:
             self.assertEqual(
@@ -2129,3 +2124,28 @@ class SSDInferenceAMDSupportTest(unittest.TestCase):
                 -1,
                 f"Entry idx={idx} at set={target_set}, slot={slot} should be invalidated",
             )
+
+
+@unittest.skipIf(*gpu_unavailable)
+class SSDInferenceAssocWarpSizeTest(unittest.TestCase):
+    """
+    The SSD inference cache associativity must equal the device warp size: the
+    cache kernels use kWarpSize for set indexing, scanning one way per lane. On
+    wave32 (RDNA) devices a hardcoded associativity of 64 makes the host
+    allocate 64-way sets that the kernel only half-scans. Unlike the rest of the
+    SSD tests, this does not need the RocksDB backend, so it runs in OSS.
+    """
+
+    def test_serving_compute_cache_sets_uses_device_warp_size(self) -> None:
+        from fbgemm_gpu.tbe.ssd.inference_serving import _device_cache_assoc
+
+        warp_size = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).warp_size
+        self.assertEqual(
+            _device_cache_assoc(),
+            warp_size,
+            f"SSD serving associativity ({_device_cache_assoc()}) must equal the "
+            f"device warp size ({warp_size}); the cache kernels scan one way per "
+            "warp lane.",
+        )


### PR DESCRIPTION
  ## Summary
  The SSD inference cache (`SSDIntNBitTableBatchedEmbeddingBags` and the Turbo SSD serving path) hardcoded associativity to 64 on ROCm. The cache kernels scan one slot per warp lane, so on wave32 (RDNA, e.g. gfx1201) the host
  allocated 64-way sets that the kernel only half-scanned — slots 32–63 were unreachable, producing incorrect lookups.

  This derives the associativity from the device warp size instead (32 on NVIDIA, either 32 or64 on AMD) via a shared `device_cache_assoc()` resolver in `tbe/ssd/common.py`, used by both inference and serving sizing math. An explicit `cache_assoc` argument is validated against the resolved warp size and raises on mismatch, so callers cannot silently request a broken geometry. The module-level `ASSOC` is now an unconditional 32 fallback for the no-device path.

  ## Test plan
  - [x] Added `SSDInferenceAssocWarpSizeTest` (runs in OSS, no RocksDB) — passes on gfx1201, asserts associativity == device warp size.
  - [x] Updated `SSDInferenceAMDSupportTest` to assert against `cache_assoc`; the  simulated-ASSOC=64 tests now patch `device_cache_assoc` to exercise the  64-way path on any device.
  - [ ] Full SSD test suite is OSS-gated (requires the RocksDB backend) — needs validation on an internal build, and a wave64 (CDNA) run to confirm no regression.